### PR TITLE
Feature/stage file proxy

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -6,12 +6,6 @@
 # Ensure tmp folder always exists.
 mkdir -p /app/web/sites/default/files/private/tmp/
 
-# All valid environments.
-if drush status --fields=bootstrap | grep -q "Successful"; then
-  drush updb -y
-  drush cr
-fi
-
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on inital deployment.
@@ -45,4 +39,10 @@ else
     echo "Drupal not installed."
   fi
 
+fi
+
+# All valid environments.
+if drush status --fields=bootstrap | grep -q "Successful"; then
+  drush updb -y
+  drush cr
 fi

--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -12,12 +12,22 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     if ! drush status --fields=bootstrap | grep -q "Successful"; then
 
         # SQL sync only in Lagoon development environments.
-        if [ ! -z "$LAGOON_ENVIRONMENT_TYPE" ]; then
+        if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
           drush sql-sync @govcms-prod @self -y
+
+          # Base configuration import with development environment overrides.
+          drush cim -y sync
+          drush cim -y dev --partial
+
+          # Enable stage file proxy post db-import.
           drush en stage_file_proxy -y
         fi
 
     else
+      # Base configuration import with development environment overrides.
+      drush cim -y sync
+      drush cim -y dev --partial
+
       # Enable stage file proxy.
       drush en stage_file_proxy -y
     fi
@@ -31,9 +41,6 @@ else
 
     # Configuration import.
     drush cim -y sync
-    if [ ! "${LAGOON_ENVIRONMENT_TYPE}" == "production" ]; then
-      drush cim -y dev --partial
-    fi
 
   else
     echo "Drupal not installed."

--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -6,16 +6,43 @@
 # Ensure tmp folder always exists.
 mkdir -p /app/web/sites/default/files/private/tmp/
 
-# Run database updates if drupal is installed.
+# All valid environments.
 if drush status --fields=bootstrap | grep -q "Successful"; then
+  drush updb -y
+  drush cr
+fi
+
+# Non production environments.
+if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
+    # Import production database on inital deployment.
+    if ! drush status --fields=bootstrap | grep -q "Successful"; then
+
+        # SQL sync only in Lagoon development environments.
+        if [ ! -z "$LAGOON_ENVIRONMENT_TYPE" ]; then
+          drush sql-sync @govcms-prod @self -y
+          drush en stage_file_proxy -y
+        fi
+
+    else
+      # Enable stage file proxy.
+      drush en stage_file_proxy -y
+    fi
+
+# Production environments.
+else
+
+  if drush status --fields=bootstrap | grep -q "Successful"; then
     mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
     drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;
+
+    # Configuration import.
     drush cim -y sync
     if [ ! "${LAGOON_ENVIRONMENT_TYPE}" == "production" ]; then
       drush cim -y dev --partial
     fi
-    drush updb -y
-    drush cr
-else
+
+  else
     echo "Drupal not installed."
+  fi
+
 fi


### PR DESCRIPTION
- Theoretical support for local development environments
- Stage File Proxy in all environments
- Stage File Proxy after an initial db sync from prod
- All valid environments will get a `drush updb` and `drush cr`

Would need to push the same changes into the GovCMS7 Lagoon codebase