### PR TITLE
Added custom PHP_MAX_INPUT_VARS env var in code and cli images.

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -1,5 +1,9 @@
 FROM govcms8dev/govcms8
 
+# Temporary override until lagoon PR is available in upstream image.
+# https://github.com/amazeeio/lagoon/issues/787
+ENV PHP_MAX_INPUT_VARS=2000
+
 COPY .docker/sanitize.sh /app/sanitize.sh
 
 COPY .docker/images/govcms8/scripts /usr/bin/

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -3,6 +3,10 @@ FROM ${CLI_IMAGE} as cli
 
 FROM govcms8dev/php
 
+# Temporary override until lagoon PR is available in upstream image.
+# https://github.com/amazeeio/lagoon/issues/787
+ENV PHP_MAX_INPUT_VARS=2000
+
 RUN apk add --update clamav clamav-libunrar \
     && freshclam
 


### PR DESCRIPTION
Updates default max_input_vars to 2000 same as D7 PR -->

https://github.com/govCMS/govcmslagoon/pull/48