### PR TITLE
Allow common dev environment settings via DEV_MODE flag

### DIFF
--- a/.docker/images/govcms8/settings/development.services.yml
+++ b/.docker/images/govcms8/settings/development.services.yml
@@ -1,0 +1,14 @@
+### Lagoon Drupal 8 development environment services file.
+#
+# This file should contain service definitions that are included on local development environments.
+#
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false
+
+services:
+  cache.backend.null: # Defines a Cache Backend Factory which is just empty, it is not used by default
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/.docker/images/govcms8/settings/development.settings.php
+++ b/.docker/images/govcms8/settings/development.settings.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @file
+ * Lagoon Drupal 8 development environment configuration file.
+ *
+ * This file will only be included on local development environments.
+ *
+ */
+
+/**
+ * Show all error messages, with backtrace information.
+ *
+ * In case the error level could not be fetched from the database, as for
+ * example the database connection failed, we rely only on this value.
+ */
+$config['system.logging']['error_level'] = 'verbose';
+
+/**
+ * Disable Google Analytics from sending dev GA data.
+ */
+$config['google_analytics.settings']['account'] = 'UA-XXXXXXXX-YY';
+
+/**
+ * Set expiration of cached pages to 0.
+ */
+$config['system.performance']['cache']['page']['max_age'] = 0;
+
+/**
+ * Disable CSS and JS aggregation.
+ */
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+
+/**
+ * Disable render caches, necessary for twig files to be reloaded on every page view.
+ */
+$settings['cache']['bins']['render'] = 'cache.backend.null';
+$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+/**
+ * Include development services yml.
+ */
+$settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/development.services.yml';

--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -246,4 +246,12 @@ if (getenv('LAGOON_ENVIRONMENT_TYPE') != 'production') {
     $config['stage_file_proxy.settings']['origin'] = getenv('STAGE_FILE_PROXY_URL');
   }
 
+  if (getenv('DEV_MODE')) {
+    if (!drupal_installation_attempted()) {
+      if (file_exists(__DIR__ . '/development.settings.php')) {
+        include __DIR__ . '/development.settings.php';
+      }
+    }
+  }
+
 }

--- a/.env.default
+++ b/.env.default
@@ -16,11 +16,14 @@ COMPOSE_PROJECT_NAME=govcms8lagoon
 # See https://docs.docker.com/compose/compose-file/#caching-options-for-volume-mounts-docker-for-mac
 # VOLUME_FLAGS=cached
 
-# Local deveopment URL.
+# Local development URL.
 LOCALDEV_URL=http://govcms8-lagoon.docker.amazee.io
 
-# Local deveopment URL (bypasses Varnish).
+# Local development URL (bypasses Varnish).
 LOCALDEV_URL_NGINX=http://govcms8-lagoon-nginx.docker.amazee.io
 
 # Namespace for resulting Docker images.
 DOCKERHUB_NAMESPACE=govcms8lagoon
+
+# Dev mode disables caches, aggregation, enables twig debug.
+DEV_MODE=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-volumes:
 x-environment:
   &default-environment
     LAGOON_ROUTE: ${LOCALDEV_URL:-http://govcms8-lagoon.docker.amazee.io}
+    DEV_MODE: ${DEV_MODE:-false}
 
 volumes:
   files: {}


### PR DESCRIPTION
If a `DEV_MODE` flag is enabled in `.env` then default development settings will apply:
- No CSS/JS aggregation
- No GA tracking
- Verbose error logging
- Max cache age 0
- Null cache backend

A `development.services.yml` file will also be included:
- Twig debug enabled
- Twig cache disabled
- Twig autoload enabled
- http.response.debug_cacheability_headers enabled
