### PR TITLE
Updated settings from ga to gtag for drupal8

### DIFF
--- a/.docker/images/govcms8/settings/production.settings.php
+++ b/.docker/images/govcms8/settings/production.settings.php
@@ -7,7 +7,7 @@
  */
 
 // Inject Google Analytics snippet on all production sites.
-$config['google_analytics.settings']['codesnippet']['after'] = "ga('create', 'UA-54970022-1', 'auto', {'name': 'govcms'}); ga('govcms.send', 'pageview', {'anonymizeIp': true})";
+$config['google_analytics.settings']['codesnippet']['after'] = "gtag('config', 'UA-54970022-1', {'name': 'govcms'}); gtag('govcms.send', 'pageview', {'anonymizeIp': true})";
 
 // Don't show any error messages on the site (will still be shown in watchdog)
 $config['system.logging']['error_level'] = 'hide';


### PR DESCRIPTION
When enabling the google analytics module on a production account console errors are bing thrown. I've logged an internal ticket: #779