### PR TITLE
Deploy tagged images on tag builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Push Docker images to Dockerhub
           command: |
-            if [ "${DEPLOY_ANY_BRANCH}" != "" ] || [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${DEPLOY_ANY_BRANCH}" != "" ] || [ "${CIRCLE_BRANCH}" == "${DEPLOY_BRANCH}" ] || [ ! -z ${CIRCLE_TAG} ]; then
               echo "IMAGE_VERSION_TAG=$CIRCLE_TAG">>.env
               docker login -u $DOCKER_USER -p $DOCKER_PASS
               export $(grep -v '^#' .env | xargs)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Push Docker images to Dockerhub
           command: |
-            if [ "${DEPLOY_ANY_BRANCH}" != "" ] || [ "${CIRCLE_BRANCH}" == "${DEPLOY_BRANCH}" ] || [ ! -z ${CIRCLE_TAG} ]; then
+            if [ "${DEPLOY_ANY_BRANCH}" != "" ] || [ "${CIRCLE_BRANCH}" == "master" ] || [ ! -z ${CIRCLE_TAG} ]; then
               echo "IMAGE_VERSION_TAG=$CIRCLE_TAG">>.env
               docker login -u $DOCKER_USER -p $DOCKER_PASS
               export $(grep -v '^#' .env | xargs)


### PR DESCRIPTION
There has been a change where `CIRCLE_BRANCH` is no longer set on tagged builds.

PR updates deployment conditions to deploy images on tagged builds.

https://github.com/govCMS/govCMS/pull/756