### PR TITLE
Support overrides to X-Frame-Options in Nginx configuration.

### DIFF
--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -5,7 +5,7 @@ FROM govcms8dev/nginx-drupal
 
 # nginx config.
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
-COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf;
+COPY .docker/images/nginx/x_frame_options.template /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.template
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
 RUN fix-permissions /etc/nginx
 
@@ -14,3 +14,8 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 
 RUN /app/sanitize.sh \
   && rm -rf /app/sanitize.sh
+
+RUN apk add gettext
+
+ARG X_FRAME_OPTIONS
+RUN envsubst < /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.template > /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -5,7 +5,7 @@ FROM govcms8dev/nginx-drupal
 
 # nginx config.
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
-COPY .docker/images/nginx/x_frame_options.template /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.template
+COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
 RUN fix-permissions /etc/nginx
 
@@ -15,7 +15,3 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 RUN /app/sanitize.sh \
   && rm -rf /app/sanitize.sh
 
-RUN apk add gettext
-
-ARG X_FRAME_OPTIONS
-RUN envsubst < /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.template > /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf

--- a/.docker/images/nginx/x_frame_options.conf
+++ b/.docker/images/nginx/x_frame_options.conf
@@ -1,2 +1,2 @@
 # GOVCMS-1331: Peripheral pages are not protected again framing attacks
-add_header X-Frame-Options "$X_FRAME_OPTIONS";
+add_header X-Frame-Options "${X_FRAME_OPTIONS}";

--- a/.docker/images/nginx/x_frame_options.conf
+++ b/.docker/images/nginx/x_frame_options.conf
@@ -1,2 +1,2 @@
 # GOVCMS-1331: Peripheral pages are not protected again framing attacks
-add_header X-Frame-Options "${X_FRAME_OPTIONS}";
+add_header X-Frame-Options "${X_FRAME_OPTIONS:-SameOrigin}";

--- a/.docker/images/nginx/x_frame_options.template
+++ b/.docker/images/nginx/x_frame_options.template
@@ -1,2 +1,2 @@
 # GOVCMS-1331: Peripheral pages are not protected again framing attacks
-add_header X-Frame-Options "SameOrigin";
+add_header X-Frame-Options "$X_FRAME_OPTIONS";

--- a/.env.default
+++ b/.env.default
@@ -27,3 +27,8 @@ DOCKERHUB_NAMESPACE=govcms8lagoon
 
 # Dev mode disables caches, aggregation, enables twig debug.
 DEV_MODE=false
+
+# X-Frame-Options header. Default disallows embedding content (e.g via iFrame) from any external domain.
+# Note: Seckit click-jacking configuration will need altering to suit if changed.
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+X_FRAME_OPTIONS=SameOrigin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,12 @@ services:
       dockerfile: $PWD/.docker/Dockerfile.nginx-drupal
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/govcms8
-        X_FRAME_OPTIONS: ${X_FRAME_OPTIONS:-SameOrigin}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/nginx-drupal
     << : *default-volumes
     environment:
       << : *default-environment
       LAGOON_LOCALDEV_URL: ${LOCALDEV_URL_NGINX:-http://govcms8-lagoon-nginx.docker.amazee.io}
+      X_FRAME_OPTIONS: ${X_FRAME_OPTIONS:-SameOrigin}
     networks:
       - amazeeio-network
       - default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       dockerfile: $PWD/.docker/Dockerfile.nginx-drupal
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/govcms8
+        X_FRAME_OPTIONS: ${X_FRAME_OPTIONS:-SameOrigin}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/nginx-drupal
     << : *default-volumes
     environment:


### PR DESCRIPTION
Provides support to individual projects allowing control over X-Frame-Options when embedding content elsewhere.

The default remains as `SAMEORIGIN`, and a change in `.env` alone is not enough to make the change occur. Seckit click-jacking will also need to be disabled, as it is installed with a default header value of `SAMEORIGIN` as well - so this needs to be configured to suit in cases where this is allowed.