### PR TITLE
Added condition to enable redis config.

### DIFF
--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -142,7 +142,7 @@ if (getenv('LAGOON')) {
 }
 
 // Redis configuration.
-if (getenv('LAGOON') && (file_exists($app_root . '/modules/contrib/redis') || file_exists($app_root . 'modules/redis')) && extension_loaded('redis')){
+if (getenv('LAGOON') && (getenv('ENABLE_REDIS'))) {
   $settings['redis.connection']['interface'] = 'PhpRedis';
   $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
   $settings['redis.connection']['port'] = 6379;


### PR DESCRIPTION
Similar PR to https://github.com/govCMS/govcmslagoon/pull/56

Disables redis by default and can be reenabled by adding the ENABLE_REDIS to lagoon-env.

redis will be disabled on all sites by default