### PR TITLE
Clear cache before configuration import

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -12,8 +12,11 @@ mkdir -p /app/web/sites/default/files/private/tmp/
 # Check for presence of config files.
 config_count=`ls -1 /app/config/default/* 2>/dev/null | wc -l`
 
-# Clear cache before configuration import
-drush cr
+# All valid environments.
+if drush status --fields=bootstrap | grep -q "Successful"; then
+  drush updb -y
+  drush cr
+fi
 
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
@@ -61,10 +64,4 @@ else
     echo "Drupal not installed."
   fi
 
-fi
-
-# All valid environments.
-if drush status --fields=bootstrap | grep -q "Successful"; then
-  drush updb -y
-  drush cr
 fi

--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -12,6 +12,9 @@ mkdir -p /app/web/sites/default/files/private/tmp/
 # Check for presence of config files.
 config_count=`ls -1 /app/config/default/* 2>/dev/null | wc -l`
 
+# Clear cache before configuration import
+drush cr
+
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on inital deployment.


### PR DESCRIPTION
### Issue: 
GOVCMSD8-145
An issue has been found which can lead to the data loss of GovCMS8 SaaS site.

Setup the local project from https://projects.govcms.gov.au/sandbox/waterrating 
Restore the database from databasebackup (Backup ID: 6d14a9e8e8e25ba9416122ba28ca5af020173fa39c0b77fcd1ca0cff1693fd7c)
Run
govcms-deploy
or 

drush cim -y sync && drush updb -y
The error message can be found from the output 

 [warning] Update function webform_update_8151 not found
 [error] Update failed: webform_update_8151 
 

After the investigation, this issue is caused by a bug in the PR https://github.com/govCMS/govcms8lagoon/pull/6 - Configuration import on deploy

And this line has a bug which can lead to data loss such as modules and themes uninstalled in certain circumstances

drush cim -y sync
 

### Solution: 
Run a cache rebuild before the config import

drush cr