### PR TITLE
[GOVCMSD8-169] Adding cache rebuild after distribution update

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -65,3 +65,8 @@ else
   fi
 
 fi
+
+# Cache rebuild after distribution update
+if drush status --fields=bootstrap | grep -q "Successful"; then
+  drush cr
+fi


### PR DESCRIPTION
We need to improve the govcms_deploy process and add the cache rebuild process after distribution update.

Otherwise, the site can throw a 500 error.