### PR TITLE
Add a release/version check step into CircleCI for confirmation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,14 @@ jobs:
           name: Run tests for containers
           command: ./tests/goss/run_all.sh
       - run:
+          name: Install site
+          command: ahoy -v install -- install_configure_form.update_status_module='array(FALSE,FALSE)'
+      - run:
+          name: Get site and module version status
+          command: |
+            ahoy drush st
+            ahoy drush pml          
+      - run:
           name: Push Docker images to Dockerhub
           command: |
             if [ "${DEPLOY_ANY_BRANCH}" != "" ] || [ "${CIRCLE_BRANCH}" == "master" ] || [ ! -z ${CIRCLE_TAG} ]; then


### PR DESCRIPTION
Adding a pair of steps to CircleCI to install a dummy site, then get a Drush status, and Drush pm:list to serve as a visual check that updates have applied properly.

(matches govcms/govcmslagoon#66)