### PR TITLE
Update version numbers to include point release indicators

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -1,4 +1,4 @@
-FROM govcms8dev/govcms8:1.0-beta3
+FROM govcms8dev/govcms8:1.0.0-beta3
 
 # Temporary override until lagoon PR is available in upstream image.
 # https://github.com/amazeeio/lagoon/issues/787

--- a/.docker/Dockerfile.mariadb-drupal
+++ b/.docker/Dockerfile.mariadb-drupal
@@ -1,1 +1,1 @@
-FROM govcms8dev/mariadb-drupal:1.0-beta3
+FROM govcms8dev/mariadb-drupal:1.0.0-beta3

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM govcms8dev/nginx-drupal:1.0-beta3
+FROM govcms8dev/nginx-drupal:1.0.0-beta3
 
 # nginx config.
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM govcms8dev/php:1.0-beta3
+FROM govcms8dev/php:1.0.0-beta3
 
 # Temporary override until lagoon PR is available in upstream image.
 # https://github.com/amazeeio/lagoon/issues/787

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -1,7 +1,7 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM govcms8dev/test:1.0-beta3
+FROM govcms8dev/test:1.0.0-beta3
 
 COPY --from=cli /app /app
 COPY .docker/sanitize.sh /app/sanitize.sh


### PR DESCRIPTION
The last change didn't include semver's point release identifier.
This will remediate that and provide a more consistent identification convention.