### PR TITLE
Add drupal/coi and drupal/config_override_core_fields

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -16,6 +16,8 @@ RUN apk add python \
     drupal/redis:^1.0 \
     drupal/stage_file_proxy:^1.0 \
     drupal/clamav:^1.1 \
+    drupal/coi:^1.0 \
+    drupal/config_override_core_fields:^1.0 \
     && mkdir -p /app/web/sites/default/files/private \
     && fix-permissions /home/.drush \
     && fix-permissions /app/drush/sites \


### PR DESCRIPTION
Given that we are using config overrides in d8:
https://github.com/govCMS/govcms8lagoon/blob/master/.docker/images/govcms8/settings/production.settings.php
https://github.com/govCMS/govcms8lagoon/blob/master/.docker/images/govcms8/settings/development.settings.php

It should be clearer which settings are being managed and therefore unchangeable - this will reduce the time needed to debug issues for all parties.

If we don't add these modules, we should consider whether agencies should have control of the overridden settings.