### PR TITLE
Update audit_site to 7.x-3.x latest HEAD

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -38,7 +38,7 @@ PHP_IMAGE_VERSION=7.1
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases
-SITE_AUDIT_VERSION=7.x-3.x-beta2
+SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION

--- a/.env.default
+++ b/.env.default
@@ -38,7 +38,7 @@ PHP_IMAGE_VERSION=7.1
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases
-SITE_AUDIT_VERSION=7.x-3.x-beta1
+SITE_AUDIT_VERSION=7.x-3.x-beta2
 
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION


### PR DESCRIPTION
Updates the Drutiny test dependency used by the test container to `7.x-3.x-beta2`.