### PR TITLE
[GOVCMSD8-362] Add findutils to govcms8lagoon cli and test images

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -20,7 +20,8 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 COPY .docker/images/govcms8/scripts /usr/bin/
 COPY .docker/images/govcms8/govcms.site.yml /app/drush/sites/
 
-RUN apk add python \
+# findutils can be removed after amazeeio/lagoon PR1077
+RUN apk --no-cache add python findutils \
     && mkdir -p /app/web/sites/default/files/private \
     && fix-permissions /home/.drush \
     && fix-permissions /app/drush/sites \

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -33,7 +33,9 @@ ARG SITE_AUDIT_VERSION
 RUN git clone --single-branch --branch=$SITE_AUDIT_VERSION https://github.com/govcms/audit-site.git /app/web/sites/all/drutiny \
     && php -d memory_limit=-1 /usr/local/bin/composer --working-dir=/app/web/sites/all/drutiny/ install --ignore-platform-reqs \
     && rm -Rf /app/web/sites/all/drutiny/.git \
-    && chmod +x /usr/bin/drutiny
+    && chmod +x /usr/bin/drutiny \
+    && apk --no-cache add findutils
+# findutils can be removed after amazeeio/lagoon PR1077
 
 # Ensure that drush and drush.launcher both work
 ENV WEBROOT=web

--- a/tests/goss/goss.govcms8.yaml
+++ b/tests/goss/goss.govcms8.yaml
@@ -29,3 +29,11 @@ file:
   /usr/bin/govcms-deploy:
     exists: true
     mode: "0755"
+    
+command:
+  find /app/ -type f -size +1M -printf '%k\t%p\n':
+    exit-status: 0
+    stdout:
+    - /app/
+    stderr: []
+    timeout: 10000

--- a/tests/goss/goss.test.yaml
+++ b/tests/goss/goss.test.yaml
@@ -26,3 +26,10 @@ command:
     - CI Site Audit
     stderr: []
     timeout: 10000
+
+  find /app/ -type f -size +1M -printf '%k\t%p\n':
+    exit-status: 0
+    stdout:
+    - /app/
+    stderr: []
+    timeout: 10000


### PR DESCRIPTION
in https://github.com/govCMS/audit-site/issues/34 some tests were identified as relying on find options not supported in the OOTB version of find.

This PR adds the full GNU findutils package to restore this functionality - it also modifies the apk command to not leave a cache in the end product image

APK adds can be removed if/when https://github.com/amazeeio/lagoon/pull/1077 lands.