### PR TITLE
[GOVCMSD8-397] Re-enable predeploy database backups.

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -12,12 +12,6 @@ mkdir -p /app/web/sites/default/files/private/tmp/
 # Check for presence of config files.
 config_count=`ls -1 /app/config/default/* 2>/dev/null | wc -l`
 
-# All valid environments.
-if drush status --fields=bootstrap | grep -q "Successful"; then
-  drush updb -y
-  drush cr
-fi
-
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     # Import production database on inital deployment.
@@ -68,5 +62,6 @@ fi
 
 # Cache rebuild after distribution update
 if drush status --fields=bootstrap | grep -q "Successful"; then
-  drush cr
+  # drush updb implicitly clears caches after the run.
+  drush updb -y
 fi


### PR DESCRIPTION
- The database update was being triggered prior to the database backup being taken this could result in an broken database backup.