### PR TITLE
Resolve composer memory limit issue, writable settings.php file

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -13,6 +13,7 @@ RUN sed -i -e "/govcms\/govcms/ s!1.x!${GOVCMS_PROJECT_VERSION}!" /app/composer.
 
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 
+ENV COMPOSER_MEMORY_LIMIT=-1
 RUN composer install -d /app
 
 COPY .docker/sanitize.sh /app/sanitize.sh
@@ -32,6 +33,7 @@ RUN apk --no-cache add python findutils \
 COPY modules/ /app/web/sites/all/modules/
 
 COPY .docker/images/govcms8/settings/ /app/web/sites/default/
+RUN chmod 444 /app/web/sites/default/settings.php
 
 # Define where the Drupal Root is located
 ENV WEBROOT=web


### PR DESCRIPTION
Added `COMPOSER_MEMORY_LIMIT` to prevent composer installation failures.
Ensure correct permissions on `settings.php`