### PR TITLE
Downgrade drush to 8.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
           command: ./tests/goss/run_all.sh
       - run:
           name: Install site
-          command: ahoy -v install -- install_configure_form.update_status_module='array(FALSE,FALSE)'
+          command: |
+            ahoy -v install -- install_configure_form.enable_update_status_module=NULL install_configure_form.enable_update_status_emails=NULL
       - run:
           name: Get site and module version status
           command: |

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
         "drupal/core": "8.6.x-dev",
-        "drush/drush": "^9.0.0",
+        "drush/drush": "^8.2.3",
         "govcms/govcms": "1.x",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",


### PR DESCRIPTION
* Using drush 8.2.3 for backup and restore
* Disable email notification during install and later (D8). If your server has no mail transfer agent, this gets rid of an error during install.