### PR TITLE
[GOVCMS-3216]: Change default favicon location

### DIFF
--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -5,7 +5,6 @@ FROM ${CLI_IMAGE} as cli
 FROM amazeeio/nginx-drupal:${LAGOON_IMAGE_VERSION}
 
 # nginx config.
-COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
 
 COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/

--- a/.docker/Dockerfile.nginx-drupal
+++ b/.docker/Dockerfile.nginx-drupal
@@ -5,9 +5,12 @@ FROM ${CLI_IMAGE} as cli
 FROM amazeeio/nginx-drupal:${LAGOON_IMAGE_VERSION}
 
 # nginx config.
-COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
-
+COPY .docker/images/nginx/x_frame_options.conf /etc/nginx/conf.d/drupal/location_drupal_append_x_frame_options.conf
 COPY .docker/images/nginx/no-robots.sh /lagoon/entrypoints/20-no-robots.sh
+
+COPY .docker/images/nginx/helpers/ /etc/nginx/helpers/
+COPY .docker/images/nginx/drupal /etc/nginx/conf.d/drupal
+
 RUN fix-permissions /etc/nginx
 
 COPY --from=cli /app /app

--- a/.docker/images/nginx/drupal/favicon.conf
+++ b/.docker/images/nginx/drupal/favicon.conf
@@ -1,4 +1,5 @@
 # Try to find a favicon in the app root otherwise default to govcms' icon.
 location /favicon.ico {
+  expires 30d;
   try_files $uri /profiles/contrib/govcms/favicon.ico;
 }

--- a/.docker/images/nginx/helpers/230-favicon.conf
+++ b/.docker/images/nginx/helpers/230-favicon.conf
@@ -1,0 +1,4 @@
+# Try to find a favicon in the app root otherwise default to govcms' icon.
+location /favicon.ico {
+  try_files $uri /profiles/contrib/govcms/favicon.ico;
+}

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -5,5 +5,5 @@ gossfile:
 file:
   /app/web/robots.txt:
     exists: true
-  /etc/nginx/conf.d/drupal/favicon.ico:
+  /etc/nginx/conf.d/drupal/favicon.conf:
     exists: true

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -5,3 +5,5 @@ gossfile:
 file:
   /app/web/robots.txt:
     exists: true
+  /etc/nginx/conf.d/drupal/favicon.ico:
+    exists: true


### PR DESCRIPTION
Adds a nginx config value to redirect /favicon to one provided by the profile if it does not exist. This happens when loading files (PDFs) or server errors as the browser will request /favicon.ico by default.