### PR TITLE
hotfix selenium/standalone-chrome:3.141.59-oxygen

### DIFF
--- a/.docker/Dockerfile.chrome
+++ b/.docker/Dockerfile.chrome
@@ -1,3 +1,3 @@
-FROM selenium/standalone-chrome
+FROM selenium/standalone-chrome:3.141.59-oxygen
 
 COPY tests/behat/files /app/tests/behat/files


### PR DESCRIPTION
Pinning to last good v74 chromedriver version (https://github.com/SeleniumHQ/docker-selenium/releases) as per https://medium.com/@alex.designworks/chromedriver-75-enforces-w3c-standard-breaking-behat-tests-460cad435545