### PR TITLE
[GOVCMSD8-396] Remove the GMP module from PHP.

### DIFF
--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -5,10 +5,6 @@ FROM ${CLI_IMAGE} as cli
 
 FROM amazeeio/php:${PHP_IMAGE_VERSION}-fpm${LAGOON_IMAGE_VERSION_PHP}
 
-RUN apk add gmp gmp-dev \
-    && docker-php-ext-install gmp \
-    && docker-php-ext-configure gmp
-
 RUN apk add --update clamav clamav-libunrar \
     && freshclam
 


### PR DESCRIPTION
- Drupal doesn't require GMP so this will remove the module from the container.