### PR TITLE
[GOVCMSD8-421] Refactored and simplified deployment script.

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -13,9 +13,8 @@ mkdir -p /app/web/sites/default/files/private/tmp/
 config_count=`ls -1 /app/config/default/*.yml 2>/dev/null | wc -l`
 dev_config_count=`ls -1 /app/config/dev/*.yml 2>/dev/null | wc -l`
 
-# Configuration import function.
-common_setup () {
-  # Ensure updates run prior to configuration import.
+# Database updates, cache rebuild, optional config imports.
+common_deploy () {
   drush updb -y
   drush cr
 
@@ -39,18 +38,18 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
         # Import prod db in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
           drush sql-sync @govcms-prod @self -y
-          common_setup
+          common_deploy
         else
           echo "Drupal not installed."
         fi
     else
-      common_setup
+      common_deploy
     fi
 # Production environments.
 else
   if drush status --fields=bootstrap | grep -q "Successful"; then
     mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
-    common_setup
+    common_deploy
     drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;
   else
     echo "Drupal not installed."

--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -10,58 +10,49 @@ sed -i "s/%%PROJECT_NAME%%/$LAGOON_PROJECT/g" /app/drush/sites/govcms.site.yml
 mkdir -p /app/web/sites/default/files/private/tmp/
 
 # Check for presence of config files.
-config_count=`ls -1 /app/config/default/* 2>/dev/null | wc -l`
+config_count=`ls -1 /app/config/default/*.yml 2>/dev/null | wc -l`
+dev_config_count=`ls -1 /app/config/dev/*.yml 2>/dev/null | wc -l`
+
+# Configuration import function.
+common_setup () {
+  # Ensure updates run prior to configuration import.
+  drush updb -y
+  drush cr
+
+  # Base configuration import with development environment overrides.
+  if [ "$config_count" -gt 0 ]; then
+    drush cim -y sync
+    if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "production" && "$dev_config_count" -gt 0 ]]; then
+      drush cim -y dev --partial
+    fi
+  fi
+
+  if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
+    # Enable stage file proxy post db-import.
+    drush en stage_file_proxy -y
+  fi
+}
 
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
-    # Import production database on inital deployment.
     if ! drush status --fields=bootstrap | grep -q "Successful"; then
-
-        # SQL sync only in Lagoon development environments.
+        # Import prod db in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
-          drush sql-sync @govcms.prod @self -y
-
-          # Base configuration import with development environment overrides.
-          if [ "$config_count" -gt 1 ]; then
-            drush cim -y sync
-            drush cim -y dev --partial
-          fi
-
-          # Enable stage file proxy post db-import.
-          drush en stage_file_proxy -y
+          drush sql-sync @govcms-prod @self -y
+          common_setup
+        else
+          echo "Drupal not installed."
         fi
-
     else
-      # Base configuration import with development environment overrides.
-      if [ "$config_count" -gt 1 ]; then
-        drush cim -y sync
-        drush cim -y dev --partial
-      fi
-
-      # Enable stage file proxy.
-      drush en stage_file_proxy -y
+      common_setup
     fi
-
 # Production environments.
 else
-
   if drush status --fields=bootstrap | grep -q "Successful"; then
     mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
-    # Configuration import.
-    if [ "$config_count" -gt 1 ]; then
-      drush cim -y sync
-    fi
-
+    common_setup
     drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;
-
   else
     echo "Drupal not installed."
   fi
-
-fi
-
-# Cache rebuild after distribution update
-if drush status --fields=bootstrap | grep -q "Successful"; then
-  # drush updb implicitly clears caches after the run.
-  drush updb -y
 fi


### PR DESCRIPTION
- Removes redundancy by moving common functionality to `common_setup`
- Fixes bug where database updates were not run after db sync on initial non-prod deployment
- Re-introduces explicit cache rebuild