### PR TITLE
[GOVCMSD8-419] Remove caches from the container build.

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -14,7 +14,7 @@ RUN sed -i -e "/govcms\/govcms/ s!1.x!${GOVCMS_PROJECT_VERSION}!" /app/composer.
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 
 ENV COMPOSER_MEMORY_LIMIT=-1
-RUN composer install -d /app && compose clearcache
+RUN composer install -d /app && composer clearcache
 
 COPY .docker/sanitize.sh /app/sanitize.sh
 

--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -14,7 +14,7 @@ RUN sed -i -e "/govcms\/govcms/ s!1.x!${GOVCMS_PROJECT_VERSION}!" /app/composer.
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 
 ENV COMPOSER_MEMORY_LIMIT=-1
-RUN composer install -d /app
+RUN composer install -d /app && compose clearcache
 
 COPY .docker/sanitize.sh /app/sanitize.sh
 

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -5,7 +5,7 @@ FROM ${CLI_IMAGE} as cli
 
 FROM amazeeio/php:${PHP_IMAGE_VERSION}-fpm${LAGOON_IMAGE_VERSION_PHP}
 
-RUN apk add --update clamav clamav-libunrar \
+RUN apk add --no-cache --update clamav clamav-libunrar \
     && freshclam
 
 COPY --from=cli /app /app


### PR DESCRIPTION
- Removes composer cache.
- Removes apk cache.

Using `composer clearcache` to remove the caches as this can clear caches in all the directories that composer is configured to use.

@see https://github.com/composer/composer/pull/3175/files