### PR TITLE
[GOVCMSD8-423] Fix the path error for .docker/Dockerfile.test

### DIFF
--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -29,8 +29,8 @@ RUN cp -r /app/web/profiles/contrib/govcms/tests /app/ \
 
 COPY .docker/images/test/drutiny /usr/bin/drutiny
 
-COPY .docker/images/test/phpunit/phpunit.xml /app/tests/phpunit
-COPY .docker/images/test/phpunit/bootstrap.php /app/tests/phpunit
+COPY .docker/images/test/phpunit/phpunit.xml /app/tests/phpunit/
+COPY .docker/images/test/phpunit/bootstrap.php /app/tests/phpunit/
 
 ARG SITE_AUDIT_VERSION
 RUN git clone --single-branch --branch=$SITE_AUDIT_VERSION https://github.com/govcms/audit-site.git /app/web/sites/all/drutiny \


### PR DESCRIPTION
ahoy test-phpunit throw up an error said 'Could not read "/app/tests/phpunit/phpunit.xml"'.
Adding a '/' at the end for above two lines fixes this error.
Without the ending '/', the phpunit.xml and bootstrap.php will be duplicated as a file named phpunit rather than 'phpunit/phpunit.xml' or 'phpunit/bootstrap.php'.