### PR TITLE
Fix clamav timeout for tests

### DIFF
--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -17,4 +17,4 @@ command:
     - "Scanned files: 1"
     - "Infected files: 1"
     stderr: []
-    timeout: 60000
+    timeout: 120000


### PR DESCRIPTION
circleCI builds are failing, as clamav is taking >60secs to complete EICAR file scan.

This hotfix allows more time for the tests to complete.