### PR TITLE
[GOVCMS-3816] Changed prod drush alias.

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -44,7 +44,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     if ! drush status --fields=bootstrap | grep -q "Successful"; then
         # Import prod db in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
-          drush sql-sync @govcms-prod @self -y
+          drush sql-sync @govcms.prod @self -y
           common_deploy
         else
           echo "Drupal not installed."
@@ -53,7 +53,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
       # @see comments for GOVCMS_TEST_CANARY above.
       if [[ "$GOVCMS_TEST_CANARY" = TRUE ]]; then
         echo "GOVCMS_TEST_CANARY is set, syncing the database."
-        drush sql-sync @govcms-prod @self -y
+        drush sql-sync @govcms.prod @self -y
       fi
       common_deploy
     fi


### PR DESCRIPTION
At some point the version of Drush changed from 8.x to 9.x in the govcms8lagoon images.

The drush alias used for v8 was previously `govcms-prod`, however the alias built for v9 is `govcms.prod`.