### PR TITLE
[GOVCMSD8-437] Allow use of existing composer.lock file to rebuild previous version

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -5,7 +5,7 @@ FROM amazeeio/php:${PHP_IMAGE_VERSION}-cli-drupal${LAGOON_IMAGE_VERSION_PHP} as 
 ARG GOVCMS_PROJECT_VERSION
 ARG DRUPAL_CORE_VERSION
 
-COPY composer.json /app/composer.json
+COPY composer.* /app/
 
 RUN sed -i -e "/govcms\/govcms/ s!^1.0!${GOVCMS_PROJECT_VERSION}!" /app/composer.json \
     && sed -i -e "/drupal\/core/ s!^8.7!${DRUPAL_CORE_VERSION}!" /app/composer.json \


### PR DESCRIPTION
Currently the govcms8 image build process does not allow the use of a previous composer.lock file to be provided. This means that a "rebuild" of a previous release will have different dependency resolution.

composer.lock files should not ordinarily be committed, but extracted from tagged releases (or re-used in the case of frequent daily builds)