### PR TITLE
[GOVCMSD8-439] Escape carat in sed expression

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -8,9 +8,9 @@ ARG DRUPAL_CORE_VERSION
 
 COPY composer.* /app/
 
-RUN sed -i -e "/govcms\/govcms/ s!^1.0!${GOVCMS_PROJECT_VERSION}!" /app/composer.json \
-    && sed -i -e "/drupal\/core/ s!^8.7!${DRUPAL_CORE_VERSION}!" /app/composer.json \
-    && sed -i -e "/webflo\/drupal-core-strict/ s!^8.7!${DRUPAL_CORE_VERSION}!" /app/composer.json
+RUN sed -i -e "/govcms\/govcms/ s!\^1.0!${GOVCMS_PROJECT_VERSION}!" /app/composer.json \
+    && sed -i -e "/drupal\/core/ s!\^8.7!${DRUPAL_CORE_VERSION}!" /app/composer.json \
+    && sed -i -e "/webflo\/drupal-core-strict/ s!\^8.7!${DRUPAL_CORE_VERSION}!" /app/composer.json
 
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 


### PR DESCRIPTION
with the carat not properly escaped, the sed fails, and composer pulls in the HEAD instead (which, when the webflo/drupal-core-strict is ahead of GovCMS, could result in dependency issues)