### PR TITLE
[GOVCMSD8-438] Add in explicit drupal-scaffold command

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -16,6 +16,7 @@ COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 
 ENV COMPOSER_MEMORY_LIMIT=-1
 RUN composer install -d /app \
+# Force drupal-scaffold to run to ensure that the needed files are always created, even if a composer.lock is provided
     && composer drupal-scaffold \
     && composer clearcache
 

--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -15,7 +15,9 @@ RUN sed -i -e "/govcms\/govcms/ s!^1.0!${GOVCMS_PROJECT_VERSION}!" /app/composer
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 
 ENV COMPOSER_MEMORY_LIMIT=-1
-RUN composer install -d /app && composer clearcache
+RUN composer install -d /app \
+    && composer drupal-scaffold \
+    && composer clearcache
 
 COPY .docker/sanitize.sh /app/sanitize.sh
 

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,9 @@
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+        ],
+        "drupal-scaffold": [
+            "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
         ]
     },
     "extra": {


### PR DESCRIPTION
This is needed when installing from composer.lock.  The Drupal-scaffold process will be skipped if building from a lockfile (as it assumes there is already a drupal system in place).

This is not the case in our base images, and therefore we have to ensure that this process runs regardless.  I have created a composer script and call it in the govcms8 dockerfile.  In circumstances where we are not installing from lockfiles, the file creation process runs twice, but this has negligible affect on timing, and zero impact on images