### PR TITLE
[GOVCMSD8-440] Update catch for CLAMAV_MODE.

### DIFF
--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -207,8 +207,8 @@ if (getenv('LAGOON')) {
 
 // ClamAV settings.
 if (getenv('LAGOON')) {
-  $clam_mode = getenv('CLAMAV_MODE') ?: 1;
-  if ($clam_mode == 0) {
+  $clam_mode = getenv('CLAMAV_MODE') !== false ? getenv('CLAMAV_MODE') : 1;
+  if ($clam_mode == 0 || strtolower($clam_mode) == 'daemon') {
     $config['clamav.settings']['scan_mode'] = 0;
     $config['clamav.settings']['mode_daemon_tcpip']['hostname'] = getenv('CLAMAV_HOST') ?: 'localhost';
     $config['clamav.settings']['mode_daemon_tcpip']['port'] = getenv('CLAMAV_PORT') ?: 3310;


### PR DESCRIPTION
'0' was being treated as a falsey always so even with the correct environment variables set it would still use the binary.

- Adds a strict type check for `!== false` as getenv will return bool if the variable is not defined.
- Adds a looser catch by setting to a string of `daemon` so we can fallback if '0' is mistreated.