### PR TITLE
Added redis config for port and cache prefix.

### DIFF
--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -145,9 +145,9 @@ if (getenv('LAGOON')) {
 if (getenv('LAGOON') && (getenv('ENABLE_REDIS'))) {
   $settings['redis.connection']['interface'] = 'PhpRedis';
   $settings['redis.connection']['host'] = getenv('REDIS_HOST') ?: 'redis';
-  $settings['redis.connection']['port'] = 6379;
+  $settings['redis.connection']['port'] = getenv('REDIS_SERVICE_PORT') ?: 6379;
 
-  $settings['cache_prefix']['default'] = getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
+  $settings['cache_prefix']['default'] = getenv('REDIS_CACHE_PREFIX') ?: getenv('LAGOON_PROJECT') . '_' . getenv('LAGOON_GIT_SAFE_BRANCH');
 
   # Do not set the cache during installations of Drupal
   if (!drupal_installation_attempted()) {


### PR DESCRIPTION
Allow overriding of the redis port and cache prefix without affecting current behaviour.

Projects will be able to customise the redis HOST, PORT and CACHE_PREFIX if required.