### PR TITLE
7.8.0 Release

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,9 +43,9 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.x-dev
-DRUPAL_CORE_VERSION=8.7.7
+GOVCMS_PROJECT_VERSION=1.0.0-beta10
+DRUPAL_CORE_VERSION=8.7.8
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v0.22.0) - make sure you change it for both lines
 # See https://github.com/amazeeio/lagoon/releases
-LAGOON_IMAGE_VERSION=v1.0.2
+LAGOON_IMAGE_VERSION=v1.1.2


### PR DESCRIPTION
Release note:

- govCMS8 1.0.0-beta10 release

- Lagoon image version v.1.1.2

- Added robots.txt for *.govcms.gov.au domains.