### PR TITLE
Remove ordered-dump flag.

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -60,7 +60,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
 # Production environments.
 else
   if drush status --fields=bootstrap | grep -q "Successful"; then
-    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --ordered-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
+    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
     common_deploy
     drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;
   else


### PR DESCRIPTION
Ordered dumps are good for readability (and diffing content); but bad for increased size on disk and import performance (every record is a single insert query instead of combined).