### PR TITLE
Update max_allowed_packet for client connections.

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -25,6 +25,9 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 COPY .docker/images/govcms8/scripts /usr/bin/
 COPY .docker/images/govcms8/govcms.site.yml /app/drush/sites/
 
+# Ensure MySQL client can accept server max_allowed_packet
+COPY .docker/images/govcms8/mariadb-client.cnf /etc/my.cnf.d
+
 RUN mkdir -p /app/web/sites/default/files/private \
     && fix-permissions /home/.drush \
     && fix-permissions /app/drush/sites \

--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -32,6 +32,9 @@ COPY .docker/images/test/drutiny /usr/bin/drutiny
 COPY .docker/images/test/phpunit/phpunit.xml /app/tests/phpunit/
 COPY .docker/images/test/phpunit/bootstrap.php /app/tests/phpunit/
 
+# Ensure MySQL client can accept server max_allowed_packet
+COPY .docker/images/govcms8/mariadb-client.cnf /etc/my.cnf.d
+
 ARG SITE_AUDIT_VERSION
 RUN git clone --single-branch --branch=$SITE_AUDIT_VERSION https://github.com/govcms/audit-site.git /app/web/sites/all/drutiny \
     && php -d memory_limit=-1 /usr/local/bin/composer --working-dir=/app/web/sites/all/drutiny/ install --ignore-platform-reqs \

--- a/.docker/images/govcms8/mariadb-client.cnf
+++ b/.docker/images/govcms8/mariadb-client.cnf
@@ -1,0 +1,2 @@
+[client]
+max_allowed_packet=256M


### PR DESCRIPTION
MySQL client also has a configuration value for `max_allowed_packet` and this can be different from the server (which in our case is 64M). This is currently using the default value of 16M. This causes issues when performing MySQL operations directly against the DB (PHP relies on the server configuration and is not subject to this problem), specifically mysqldump (`drush sql-dump`). If a row is inserted that is higher than 16M the mysql client cannot retrieve the value.