### PR TITLE
Upgrade to PHP7.3.

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -33,8 +33,8 @@ DEV_MODE=false
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 X_FRAME_OPTIONS=SameOrigin
 
-# Set the PHP version to use for the upstream dockerfiles (currently 7.2 - use 7.1/7.3 for testing or b/c)
-PHP_IMAGE_VERSION=7.2
+# Set the PHP version to use for the upstream dockerfiles (currently 7.3)
+PHP_IMAGE_VERSION=7.3
 
 # Set the version of the site audit script to use - you can use a tag or branch reference here
 # See https://github.com/govCMS/audit-site/releases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         GOVCMS_PROJECT_VERSION: ${GOVCMS_PROJECT_VERSION:-^1.0}
         DRUPAL_CORE_VERSION: ${DRUPAL_CORE_VERSION:-^8.7}
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.2}
+        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.3}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/govcms8
     << : *default-volumes
     environment:
@@ -36,7 +36,7 @@ services:
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/govcms8
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.2}
+        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.3}
         SITE_AUDIT_VERSION: ${SITE_AUDIT_VERSION:-7.x-3.x}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/test
     << : *default-volumes
@@ -69,7 +69,7 @@ services:
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/govcms8
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.2}
+        PHP_IMAGE_VERSION: ${PHP_IMAGE_VERSION:-7.3}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/php
     << : *default-volumes
     environment:


### PR DESCRIPTION
D8 core and vast majority of contrib is 7.3 compatible. 

7.3 brings modest performance improvements and is a low risk upgrade. There are `edge73` images pushed based on this branch (`govcms8lagoon/php:edge73`) ready for testing.