### PR TITLE
Set default cache time to 1h.

### DIFF
--- a/.docker/images/govcms8/settings/production.settings.php
+++ b/.docker/images/govcms8/settings/production.settings.php
@@ -12,8 +12,11 @@ $config['google_analytics.settings']['codesnippet']['after'] = "gtag('config', '
 // Don't show any error messages on the site (will still be shown in watchdog)
 $config['system.logging']['error_level'] = 'hide';
 
-// Expiration of cached pages on Varnish to 15 min.
-$config['system.performance']['cache']['page']['max_age'] = 900;
+// Set max cache lifetime to 1h by default.
+$config['system.performance']['cache']['page']['max_age'] = 3600;
+if (is_numeric($max_age=GETENV('CACHE_MAX_AGE'))) {
+  $config['system.performance']['cache']['page']['max_age'] = $max_age;
+}
 
 // Aggregate CSS files on.
 $config['system.performance']['css']['preprocess'] = 1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ x-environment:
   &default-environment
     LAGOON_ROUTE: ${LOCALDEV_URL:-http://govcms8lagoon.docker.amazee.io}
     DEV_MODE: ${DEV_MODE:-false}
+    CACHE_MAX_AGE: ${CACHE_MAX_AGE:-3600}
 
 volumes:
   files: {}


### PR DESCRIPTION
Alters default max-age header to 1h with env var override.