### PR TITLE
Update the max upload size to 256m.

### DIFF
--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -11,5 +11,7 @@ RUN apk add --no-cache --update clamav clamav-libunrar \
 COPY --from=cli /app /app
 COPY .docker/sanitize.sh /app/sanitize.sh
 
+COPY .docker/images/php/00-govcms.ini /usr/local/etc/php/conf.d/
+
 RUN /app/sanitize.sh \
   && rm -rf /app/sanitize.sh

--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -8,10 +8,9 @@ FROM amazeeio/php:${PHP_IMAGE_VERSION}-fpm-${LAGOON_IMAGE_VERSION}
 RUN apk add --no-cache --update clamav clamav-libunrar \
     && freshclam
 
+COPY .docker/images/php/00-govcms.ini /usr/local/etc/php/conf.d/
 COPY --from=cli /app /app
 COPY .docker/sanitize.sh /app/sanitize.sh
-
-COPY .docker/images/php/00-govcms.ini /usr/local/etc/php/conf.d/
 
 RUN /app/sanitize.sh \
   && rm -rf /app/sanitize.sh

--- a/.docker/images/nginx/helpers/000-client_max_body.conf
+++ b/.docker/images/nginx/helpers/000-client_max_body.conf
@@ -1,0 +1,3 @@
+# Set the client max body to change streaming behaviour
+# between nginx and php.
+client_max_body_size  256M;

--- a/.docker/images/php/00-govcms.ini
+++ b/.docker/images/php/00-govcms.ini
@@ -1,0 +1,3 @@
+[PHP]
+
+upload_max_filesize=256M

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -6,7 +6,7 @@ command:
   nginx -T | grep client_max_body_size | tail -1:
     exit-status: 0
     stdout:
-      - "client_max_body_size 256M;"
+      - "client_max_body_size  256M;"
 
 file:
   /app/web/robots.txt:

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -2,11 +2,12 @@
 gossfile:
   sanitise.yaml: {}
 
-file:
+command:
   nginx -T | grep client_max_body_size | tail -1:
     exit-status: 0
     stdout:
       - "client_max_body_size 256M;"
 
+file:
   /app/web/robots.txt:
     exists: true

--- a/tests/goss/goss.nginx-drupal.yaml
+++ b/tests/goss/goss.nginx-drupal.yaml
@@ -3,5 +3,10 @@ gossfile:
   sanitise.yaml: {}
 
 file:
+  nginx -T | grep client_max_body_size | tail -1:
+    exit-status: 0
+    stdout:
+      - "client_max_body_size 256M;"
+
   /app/web/robots.txt:
     exists: true

--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -3,6 +3,11 @@ gossfile:
   sanitise.yaml: {}
 
 command:
+  php -r "echo ini_get('upload_max_filesize');":
+    exit-status: 0
+    stdout:
+      - "256M"
+
   which clamscan:
     exit-status: 0
     stdout:


### PR DESCRIPTION
- Changes nginx max_client_size to 256m
- Changes php max upload size to 256m
- Add goss checking for configuration.