### PR TITLE
Rolled back default max-age header to 900s.

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -44,6 +44,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
     if ! drush status --fields=bootstrap | grep -q "Successful"; then
         # Import prod db in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
+          drush sql-drop -y
           drush sql-sync @govcms.prod @self -y
           common_deploy
         else
@@ -53,6 +54,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
       # @see comments for GOVCMS_TEST_CANARY above.
       if [[ "$GOVCMS_TEST_CANARY" = TRUE ]]; then
         echo "GOVCMS_TEST_CANARY is set, syncing the database."
+        drush sql-drop -y
         drush sql-sync @govcms.prod @self -y
       fi
       common_deploy

--- a/.docker/images/govcms8/settings/production.settings.php
+++ b/.docker/images/govcms8/settings/production.settings.php
@@ -13,7 +13,7 @@ $config['google_analytics.settings']['codesnippet']['after'] = "gtag('config', '
 $config['system.logging']['error_level'] = 'hide';
 
 // Set max cache lifetime to 1h by default.
-$config['system.performance']['cache']['page']['max_age'] = 3600;
+$config['system.performance']['cache']['page']['max_age'] = 900;
 if (is_numeric($max_age=GETENV('CACHE_MAX_AGE'))) {
   $config['system.performance']['cache']['page']['max_age'] = $max_age;
 }


### PR DESCRIPTION
Ensure database drop before sync.