### PR TITLE
Replaced CI runner image with govcms/govcms-ci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: integratedexperts/circleci2-builder
+      - image: quay.io/govcms/govcms-ci:feature_updates
         environment:
           COMPOSER_ALLOW_SUPERUSER: 1
           COMPOSE_PROJECT_NAME: govcms8lagoon

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: quay.io/govcms/govcms-ci:feature_updates
+      - image: quay.io/govcms/govcms-ci
         environment:
           COMPOSER_ALLOW_SUPERUSER: 1
           COMPOSE_PROJECT_NAME: govcms8lagoon

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 
-image: quay.io/govcms/govcms-ci
+image: quay.io/govcms/govcms-ci:feature_updates
 
 services:
   - "docker:dind"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 
-image: quay.io/govcms/govcms-ci:feature_updates
+image: quay.io/govcms/govcms-ci
 
 services:
   - "docker:dind"


### PR DESCRIPTION
**Do not merge this as-is.** 

Once the CI build passes:
1. The PR https://github.com/govCMS/govcms-ci/pull/3 needs to be merged
2. The image needs to be released to Quay.io (automated once merged)
3. This PR needs to be updated to remove `feature_updates` image label.
4. CI has to re-run again.
5. This PR only then can be merged.