### PR TITLE
Better Solr configuration defaults

### DIFF
--- a/modules/lagoon/lagoon_search/config/install/block.block.exposedformsolr_searchpage_1.yml
+++ b/modules/lagoon/lagoon_search/config/install/block.block.exposedformsolr_searchpage_1.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.solr_search
+  module:
+    - views
+  theme:
+    - govcms8_uikit_starter
+id: exposedformsolr_searchpage_1
+theme: govcms8_uikit_starter
+region: search
+weight: 0
+provider: null
+plugin: 'views_exposed_filter_block:solr_search-page_1'
+settings:
+  id: 'views_exposed_filter_block:solr_search-page_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+visibility: {  }

--- a/modules/lagoon/lagoon_search/config/install/block.block.exposedformsolr_searchpage_1.yml
+++ b/modules/lagoon/lagoon_search/config/install/block.block.exposedformsolr_searchpage_1.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - views.view.solr_search
   module:
+    - system
     - views
   theme:
     - govcms8_uikit_starter
@@ -17,6 +18,11 @@ settings:
   id: 'views_exposed_filter_block:solr_search-page_1'
   label: ''
   provider: views
-  label_display: visible
+  label_display: '0'
   views_label: ''
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/search/*'
+    negate: true
+    context_mapping: {  }

--- a/modules/lagoon/lagoon_search/config/install/block.block.exposedformsolr_searchpage_1_2.yml
+++ b/modules/lagoon/lagoon_search/config/install/block.block.exposedformsolr_searchpage_1_2.yml
@@ -8,21 +8,21 @@ dependencies:
     - views
   theme:
     - govcms8_uikit_starter
-id: exposedformsolr_searchpage_1
+id: exposedformsolr_searchpage_1_2
 theme: govcms8_uikit_starter
-region: search
-weight: 0
+region: content
+weight: -4
 provider: null
 plugin: 'views_exposed_filter_block:solr_search-page_1'
 settings:
   id: 'views_exposed_filter_block:solr_search-page_1'
   label: ''
   provider: views
-  label_display: visible
+  label_display: '0'
   views_label: ''
 visibility:
   request_path:
     id: request_path
     pages: "/search*\r\n/search/*"
-    negate: true
+    negate: false
     context_mapping: {  }

--- a/modules/lagoon/lagoon_search/config/install/search_api.index.solr_index.yml
+++ b/modules/lagoon/lagoon_search/config/install/search_api.index.solr_index.yml
@@ -2,9 +2,9 @@ langcode: en
 status: true
 dependencies:
   module:
-    - search_api_solr
     - node
     - search_api
+    - search_api_solr
   config:
     - field.storage.node.body
     - search_api.server.lagoon_solr
@@ -14,8 +14,8 @@ third_party_settings:
     commit_before_finalize: false
     commit_after_finalize: false
 id: solr_index
-name: 'solr index'
-description: ''
+name: 'Solr Index'
+description: 'Default search index using the solr search server'
 read_only: false
 field_settings:
   title:

--- a/modules/lagoon/lagoon_search/config/install/search_api.index.solr_index.yml
+++ b/modules/lagoon/lagoon_search/config/install/search_api.index.solr_index.yml
@@ -1,0 +1,56 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api_solr
+    - node
+    - search_api
+  config:
+    - field.storage.node.body
+    - search_api.server.lagoon_solr
+third_party_settings:
+  search_api_solr:
+    finalize: false
+    commit_before_finalize: false
+    commit_after_finalize: false
+id: solr_index
+name: 'solr index'
+description: ''
+read_only: false
+field_settings:
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: text
+    dependencies:
+      module:
+        - node
+  body:
+    label: Body
+    datasource_id: 'entity:node'
+    property_path: body
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.body
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  rendered_item: {  }
+  solr_date_range: {  }
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: true
+  cron_limit: 50
+server: lagoon_solr

--- a/modules/lagoon/lagoon_search/config/install/search_api.server.lagoon_solr.yml
+++ b/modules/lagoon/lagoon_search/config/install/search_api.server.lagoon_solr.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - search_api_solr.solr_field_type.text_und_6_0_0
   module:
     - search_api_solr
 id: lagoon_solr

--- a/modules/lagoon/lagoon_search/config/install/search_api.server.lagoon_solr.yml
+++ b/modules/lagoon/lagoon_search/config/install/search_api.server.lagoon_solr.yml
@@ -7,7 +7,7 @@ dependencies:
     - search_api_solr
 id: lagoon_solr
 name: 'Lagoon Solr'
-description: ''
+description: 'Default solr search server'
 backend: search_api_solr
 backend_config:
   connector: standard

--- a/modules/lagoon/lagoon_search/config/install/views.view.solr_search.yml
+++ b/modules/lagoon/lagoon_search/config/install/views.view.solr_search.yml
@@ -1,0 +1,332 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - search_api.index.solr_index
+  module:
+    - search_api
+    - text
+id: solr_search
+label: 'Solr Search'
+module: views
+description: ''
+tag: ''
+base_table: search_api_index_solr_index
+base_field: search_api_id
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          bypass_access: false
+          skip_access: false
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 20
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: default
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            title: title
+            body: body
+          separator: ''
+          hide_empty: false
+      fields:
+        title:
+          id: title
+          table: search_api_index_solr_index
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h2
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+          plugin_id: search_api_field
+        body:
+          id: body
+          table: search_api_index_solr_index
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 600
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+          plugin_id: search_api_field
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_solr_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: Search
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: fulltext_search
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              content_author: '0'
+              content_approver: '0'
+              site_administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+          plugin_id: search_api_fulltext
+      sorts: {  }
+      title: ''
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_solr_index
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: fulltext_search
+            fallback: ''
+            multiple: and
+          default_argument_skip_url: false
+          summary_options: {  }
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          parse_mode: terms
+          fields: {  }
+          conjunction: OR
+          plugin_id: search_api_fulltext
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+      tags:
+        - 'config:field.storage.node.body'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: search/%
+      exposed_block: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+      tags:
+        - 'config:field.storage.node.body'

--- a/modules/lagoon/lagoon_search/config/install/views.view.solr_search.yml
+++ b/modules/lagoon/lagoon_search/config/install/views.view.solr_search.yml
@@ -10,7 +10,7 @@ dependencies:
 id: solr_search
 label: 'Solr Search'
 module: views
-description: ''
+description: 'Default content search using the solr search'
 tag: ''
 base_table: search_api_index_solr_index
 base_field: search_api_id
@@ -61,16 +61,24 @@ display:
             previous: ‹‹
             next: ››
       style:
-        type: default
-      row:
-        type: fields
+        type: html_list
         options:
-          default_field_elements: true
-          inline:
-            title: title
-            body: body
-          separator: ''
-          hide_empty: false
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: search_api
+        options:
+          view_modes:
+            'entity:node':
+              govcms_blog_article: search
+              govcms_event: search
+              govcms_foi: search
+              govcms_news_and_media: search
+              govcms_standard_page: search
       fields:
         title:
           id: title
@@ -220,7 +228,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          operator: or
+          operator: and
           value: ''
           group: 1
           exposed: true
@@ -242,7 +250,7 @@ display:
               content_author: '0'
               content_approver: '0'
               site_administrator: '0'
-            placeholder: ''
+            placeholder: 'What are you looking for?'
           is_grouped: false
           group_info:
             label: ''
@@ -261,48 +269,23 @@ display:
           plugin_id: search_api_fulltext
       sorts: {  }
       title: ''
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments:
-        search_api_fulltext:
-          id: search_api_fulltext
-          table: search_api_index_solr_index
-          field: search_api_fulltext
+      header:
+        result:
+          id: result
+          table: views
+          field: result
           relationship: none
           group_type: group
           admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: query_parameter
-          default_argument_options:
-            query_param: fulltext_search
-            fallback: ''
-            multiple: and
-          default_argument_skip_url: false
-          summary_options: {  }
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          parse_mode: terms
-          fields: {  }
-          conjunction: OR
-          plugin_id: search_api_fulltext
+          empty: false
+          content: 'Displaying @start - @end of @total'
+          plugin_id: result
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
       display_extenders: {  }
+      css_class: 'views--layout views--layout--full-width'
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Because establishing configuration for Solr testing each release is such a burden, we've discussed the opportunity to add in defaults for Solr via the lagoon_search custom module currently used to add the Lagoon solr server.

The configuration wasn't quite enough to look nice, so there's an accompanying PR in the UI starter kit theme here:

* govCMS/govcms8_uikit_starter#117
