### PR TITLE
[GOVCMSD8-433]: Update Fast404 configuration

### DIFF
--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -34,7 +34,7 @@ $contrib_path = 'modules/contrib';
 if (file_exists($contrib_path . '/fast404/fast404.inc')) {
   include_once $contrib_path . 'fast404/fast404.inc';
 }
-$settings['fast404_exts'] = '/^(?!robots)^(?!\/system\/files).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
+$settings['fast404_exts'] = getenv('GOVCMS_FAST404_EXTS') ?: '/^(?!robots)^(?!\/system\/files).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 $settings['fast404_string_whitelisting'] = array('robots.txt', 'system/files');
 

--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -34,9 +34,9 @@ $contrib_path = 'modules/contrib';
 if (file_exists($contrib_path . '/fast404/fast404.inc')) {
   include_once $contrib_path . 'fast404/fast404.inc';
 }
-$settings['fast404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
+$settings['fast404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
-$settings['fast404_whitelist'] = array('robots.txt', 'system/files');
+$settings['fast404_string_whitelisting'] = array('robots.txt', 'system/files');
 
 // Allow custom themes to provide custom 404 pages.
 // By placing a file called 404.html in the root of their theme repository.

--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -34,7 +34,7 @@ $contrib_path = 'modules/contrib';
 if (file_exists($contrib_path . '/fast404/fast404.inc')) {
   include_once $contrib_path . 'fast404/fast404.inc';
 }
-$settings['fast404_exts'] = '/^(?!robots)^(?!sites\/default\/files\/private).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
+$settings['fast404_exts'] = '/^(?!robots)^?!\/system\/files).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 $settings['fast404_string_whitelisting'] = array('robots.txt', 'system/files');
 

--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -34,7 +34,7 @@ $contrib_path = 'modules/contrib';
 if (file_exists($contrib_path . '/fast404/fast404.inc')) {
   include_once $contrib_path . 'fast404/fast404.inc';
 }
-$settings['fast404_exts'] = '/^(?!robots)^?!\/system\/files).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
+$settings['fast404_exts'] = '/^(?!robots)^(?!\/system\/files).*\.(?:png|gif|jpe?g|svg|tiff|bmp|raw|webp|pdf?|docx?|xlsx?|pptx?|swf|flv|cgi|dll|exe|nsf|cfm|ttf|bat|pl|asp|ics|rtf)$/i';
 $settings['fast404_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
 $settings['fast404_string_whitelisting'] = array('robots.txt', 'system/files');
 


### PR DESCRIPTION
Superseded variable names break functionality in current configuration.
This PR updates the variable name and adds the `pdf` extension to supported extensions.