### PR TITLE
[GOVCMS-4396] Add mydumper/myloader.

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -42,3 +42,24 @@ RUN chmod 444 /app/web/sites/default/settings.php
 
 # Define where the Drupal Root is located
 ENV WEBROOT=web
+
+# Compile mydumper/myloader.
+ENV LIB_PACKAGES="glib-dev mariadb-dev zlib-dev pcre-dev libressl-dev" \
+    BUILD_PACKAGES="cmake build-base git" \
+    BUILD_PATH="/opt/mydumper-src/"
+
+RUN apk --no-cache add \
+          $BUILD_PACKAGES \
+          $LIB_PACKAGES \
+    && \
+    git clone https://github.com/maxbube/mydumper.git $BUILD_PATH && \
+    cd $BUILD_PATH && \
+    cmake . && \
+    make && \
+    mv ./mydumper /usr/bin/. && \
+    mv ./myloader /usr/bin/. && \
+    cd / && rm -rf $BUILD_PATH && \
+    apk del $BUILD_PACKAGES && \
+    rm -f /usr/lib/*.a && \
+    (rm "/tmp/"* 2>/dev/null || true) && \
+    (rm -rf /var/cache/apk/* 2>/dev/null || true)


### PR DESCRIPTION
Adds the `mydumper` and `myloader` binaries.

Image size before: 510MB
Image size after: 645MB

Wiki: https://projects.govcms.gov.au/GovCMS/wiki/-/wikis/MyDumper/MySQL-import-and-export-(mydumper-and-loader)

## mydumper / myloader

The more performant mydumper/myloader tools will shortly become available in govcmslagoon images. This brings vastly superior database import/export speeds to forklifts and common tasks (e.g predeploy backups, nightly db backups).

Dump:
```
mydumper --database=drupal --user=drupal --password=drupal --host=mariadb --outputdir=web/sites/default/files/private/db_18Feb/
```

Import:
```
myloader --database=drupal --user=drupal --password=drupal --host=mariadb --directory=web/sites/default/files/private/db_18Feb/
```

**Note: ** To test this locally you will need to grant additional permissions (not required with RDS).
```
docker-compose exec -T mariadb mysql -uroot -pLag00n -e "GRANT SUPER,RELOAD ON *.* TO 'drupal'@'%'; FLUSH PRIVILEGES;"
```



## Time comparison

Simple time comparison using vanilla GovCMS8 install.

Note this is a baseline, the results would become more pronounced on sites with larger datasets.


### Dump

Via drush sql-dump:
```
cli-drupal:/app$ time drush sql-dump > /tmp/drush.sql

real	0m0.737s
user	0m0.209s
sys	0m0.205s
```

Via mydumper:
```
cli-drupal:/app$ time mydumper --database=drupal --user=drupal --password=drupal --host=mariadb --outputdir=web/sites/default/files/private/db_18Feb/

real	0m0.142s
user	0m0.044s
sys	0m0.136s
```

~5x faster.

### Import
Via drush sqlc:
```
cli-drupal:/app$ time drush sqlc < /tmp/drush.sql

real	0m1.961s
user	0m0.204s
sys	0m0.143s
```

Via myloader:
```
cli-drupal:/app$ time myloader --database=drupal --user=drupal --password=drupal --host=mariadb --directory=web/sites/default/files/private/db_18Feb/

real	0m1.335s
user	0m0.039s
sys	0m0.043s
```

0.68x faster