### PR TITLE
[GOVCMS-4391]: Add scaffold-tooling to the base image.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "webmozart/path-util": "^2.3",
         "drupal/core-recommended": "^8.8",
         "zaporylie/composer-drupal-optimizations": "^1.0",
-        "govcms/scaffold-tooling": "^1.0"
+        "govcms/scaffold-tooling": "dev-feature/govcms-4390-sub-scripts-deploy"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"

--- a/composer.json
+++ b/composer.json
@@ -25,19 +25,12 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
-        "drupal/console": "^1.0.2",
-        "drush/drush": "^9.0.0",
         "govcms/govcms": "^1.0",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
         "drupal/core-recommended": "^8.8",
-        "drupal/fast_404":"1.0.0-alpha4",
-        "drupal/lagoon_logs":"1.x-dev",
-        "drupal/redis":"1.1.0",
-        "drupal/stage_file_proxy":"1.0.0-alpha3",
-        "drupal/clamav":"1.1.0",
         "zaporylie/composer-drupal-optimizations": "^1.0",
-        "govcms/scaffold-tooling": "^1.0"
+        "govcms/scaffold-tooling": "dev-feature/govcms-4390-sub-scripts-deploy"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "webmozart/path-util": "^2.3",
         "drupal/core-recommended": "^8.8",
         "zaporylie/composer-drupal-optimizations": "^1.0",
-        "govcms/scaffold-tooling": "dev-feature/govcms-4390-sub-scripts-deploy"
+        "govcms/scaffold-tooling": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
         {
             "type": "vcs",
             "url": "git@github.com:govcms/govcms8.git"
+        },
+        {
+            "type": "vcs",
+            "url": "git@github.com:govCMS/scaffold-tooling.git"
         }
     ],
     "require": {
@@ -32,7 +36,8 @@
         "drupal/redis":"1.1.0",
         "drupal/stage_file_proxy":"1.0.0-alpha3",
         "drupal/clamav":"1.1.0",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
+        "zaporylie/composer-drupal-optimizations": "^1.0",
+        "govcms/scaffold-tooling": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
- Add the scaffold tooling repository to the base image. This will include the necessary deploy scripts to the images.