### PR TITLE
Fix clamscan test

### DIFF
--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -13,7 +13,7 @@ command:
   echo -e "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" > /tmp/virus && clamscan /tmp/virus
     exit-status: 1
     stdout:
-    - "Clamav.Test.File-7 FOUND"
+    - "FOUND"
     - "Scanned files: 1"
     - "Infected files: 1"
     stderr: []

--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -9,11 +9,11 @@ command:
     - /usr/bin/clamscan
     stderr: []
     timeout: 20000
-  # Test that viruses can be discovered.
-  curl http://www.eicar.org/download/eicar.com.txt | clamscan -:
+    # Test that viruses can be discovered.
+    echo -e "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" > /tmp/virus && clamscan /tmp/virus
     exit-status: 1
     stdout:
-    - "Eicar-Test-Signature FOUND"
+    - "Clamav.Test.File-7 FOUND"
     - "Scanned files: 1"
     - "Infected files: 1"
     stderr: []

--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -9,8 +9,8 @@ command:
     - /usr/bin/clamscan
     stderr: []
     timeout: 20000
-    # Test that viruses can be discovered.
-    echo -e "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" > /tmp/virus && clamscan /tmp/virus
+  # Test that viruses can be discovered.
+  echo -e "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" > /tmp/virus && clamscan /tmp/virus
     exit-status: 1
     stdout:
     - "Clamav.Test.File-7 FOUND"

--- a/tests/goss/goss.php.yaml
+++ b/tests/goss/goss.php.yaml
@@ -10,7 +10,7 @@ command:
     stderr: []
     timeout: 20000
   # Test that viruses can be discovered.
-  echo -e "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" > /tmp/virus && clamscan /tmp/virus
+  echo -e "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" > /tmp/virus && clamscan /tmp/virus:
     exit-status: 1
     stdout:
     - "FOUND"


### PR DESCRIPTION
* Remove dependency on eicar.org uptime (many failures in past due to network connectivity issue)
* Alter test file + approach (piped output was not working)