### PR TITLE
Updated test helpers and coding standards.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Test that Redis is functional
           command: |
-            # Set ENABLE_REDIS env var and warm cache with a bootstrap
+            # Set ENABLE_REDIS env var and warm cache with a bootstrap.
             docker-compose exec -T --env ENABLE_REDIS=true cli drush status
             redisKeys=$(docker-compose exec -T redis redis-cli KEYS '*' | wc -l)
             if [[ $redisKeys -le 1 ]]; then
@@ -47,6 +47,24 @@ jobs:
             else
               echo "Redis success: Redis contains $redisKeys keys."
             fi
+      - run:
+          name: Test Nginx configuration
+          command: |
+            # Wait for nginx container.
+            docker-compose exec test dockerize -wait tcp://nginx:8080 -timeout 1m
+            # Validate nginx configuration.
+            docker-compose exec nginx nginx -t
+            # Validate composer.json and composer.lock configuration for tests.
+            composer validate --strict -d .docker/images/nginx/tests
+            # Install dependencies for tests.
+            composer install -d .docker/images/nginx/tests
+            # Create artifact directory.
+            mkdir -p /tmp/artifacts/phpunit
+            # Run tests and store logs in artifacts directory.
+            .docker/images/nginx/tests/vendor/bin/phpunit -c .docker/images/nginx/tests/phpunit.xml --log-junit /tmp/artifacts/phpunit/nginx.xml
+      - store_test_results:
+          path: /tmp/artifacts/phpunit
+          when: always
       - run:
           name: Push Docker images to Dockerhub
           command: |
@@ -58,20 +76,3 @@ jobs:
             else
               echo "Skipping deployment"
             fi
-      - run:
-          name: Test Nginx configuration
-          command: |
-            docker-compose exec nginx nginx -t
-            composer install -d .docker/images/nginx/tests
-            .docker/images/nginx/tests/vendor/bin/phpunit -c .docker/images/nginx/tests/phpunit.xml
-
-workflows:
-  version: 2
-  main:
-    jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,3 @@ jobs:
       - store_test_results:
           path: /tmp/artifacts/phpunit
           when: always
-      - run:
-          name: Push Docker images to Dockerhub
-          command: |
-            if [ "${DEPLOY_ANY_BRANCH}" != "" ] || [ "${CIRCLE_BRANCH}" == "master" ] || [ ! -z ${CIRCLE_TAG} ]; then
-              echo "IMAGE_VERSION_TAG=$CIRCLE_TAG">>.env
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              export $(grep -v '^#' .env | xargs)
-              ahoy push
-            else
-              echo "Skipping deployment"
-            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,9 @@ jobs:
           name: Test Nginx configuration
           command: |
             # Wait for nginx container.
-            docker-compose exec test dockerize -wait tcp://nginx:8080 -timeout 1m
+            docker-compose exec -T test dockerize -wait tcp://nginx:8080 -timeout 1m
             # Validate nginx configuration.
-            docker-compose exec nginx nginx -t
+            docker-compose exec -T nginx nginx -t
             # Validate composer.json and composer.lock configuration for tests.
             composer validate --strict -d .docker/images/nginx/tests
             # Install dependencies for tests.

--- a/.docker/images/nginx/tests/bootstrap.php
+++ b/.docker/images/nginx/tests/bootstrap.php
@@ -6,29 +6,48 @@
 
 include_once __DIR__ . '/vendor/autoload.php';
 
-function get_curl_headers($path = "/", $opts = NULL)
-{
-  $uri = getenv('LOCALDEV_URL') ?: 'http://nginx:8080';
+/**
+ * Execute CURL and get response headers.
+ *
+ * @param string $path
+ *   (optional) URL path to get the headers for. Defaults to '/'.
+ * @param null|string $opts
+ *   (optional) CURL-compatible string of headers. Defaults to NULL.
+ *
+ * @return array
+ *   Array of returned headers.
+ *
+ * @throws \RuntimeException
+ *   If CURL exited with an error.
+ */
+function get_curl_headers($path = '/', $opts = NULL) {
+  $uri = 'http://nginx:8080';
+  $uri = $uri . '/' . ltrim($path, '/');
 
-  $response = null;
+  $response = NULL;
+  exec("docker-compose exec -T test curl -s {$uri} -I {$opts} 2>&1", $response, $ret);
 
-  $path = '/' . ltrim($path, '/');
+  if (is_debug()) {
+    fwrite(STDERR, sprintf('CURL exit code : %s', $ret) . PHP_EOL);
+    fwrite(STDERR, sprintf('CURL URI       : %s', $uri) . PHP_EOL);
+    fwrite(STDERR, sprintf('CURL response  : %s', PHP_EOL . implode(PHP_EOL, $response)) . PHP_EOL);
+  }
 
-  exec("docker-compose exec -T test curl {$uri}{$path} -I {$opts} 2>/dev/null", $response);
-
-  if (empty($response)) {
-    return [];
+  if ($ret != 0) {
+    throw new \RuntimeException(sprintf('CURL exited with error code "%s" and response %s.', $ret, PHP_EOL . implode(PHP_EOL, $response)));
   }
 
   $response = array_map('trim', $response);
 
   foreach ($response as $line) {
-    if (strpos($line, 'HTTP') !== false) {
+    if (strpos($line, 'HTTP') !== FALSE) {
       $part = explode(' ', $line);
       $headers['Status'] = trim($part[1]);
       continue;
     }
+
     $part = explode(':', $line);
+
     if (count($part) == 2) {
       $headers[$part[0]] = trim($part[1]);
     }
@@ -37,18 +56,43 @@ function get_curl_headers($path = "/", $opts = NULL)
   return $headers;
 }
 
-function curl_get_content($path = "/", $opts = NULL)
-{
-  $uri = getenv('LOCALDEV_URL') ?: 'http://nginx:8080';
+/**
+ * Execute CURL and get response.
+ *
+ * @param string $path
+ *   (optional) URL path to get the headers for. Defaults to '/'.
+ * @param null|string $opts
+ *   (optional) String of CURL options. Defaults to NULL.
+ *
+ * @return string
+ *   Response as a string.
+ *
+ * @throws \RuntimeException
+ *   If CURL exited with an error.
+ */
+function curl_get_content($path = '/', $opts = NULL) {
+  $uri = 'http://nginx:8080';
+  $uri = $uri . '/' . ltrim($path, '/');
 
-  $response = null;
-  $path = '/' . ltrim($path, '/');
+  $response = NULL;
+  exec("docker-compose exec -T test curl -s {$uri} {$opts} 2>&1", $response, $ret);
 
-  exec("docker-compose exec -T test curl {$uri}{$path} {$opts} 2>/dev/null", $response);
+  if (is_debug()) {
+    fwrite(STDERR, sprintf('CURL exit code : %s', $ret) . PHP_EOL);
+    fwrite(STDERR, sprintf('CURL URI       : %s', $uri) . PHP_EOL);
+    fwrite(STDERR, sprintf('CURL response  : %s', PHP_EOL . implode(PHP_EOL, $response)) . PHP_EOL);
+  }
 
-  if (empty($response)) {
-    return FALSE;
+  if ($ret != 0) {
+    throw new \RuntimeException(sprintf('CURL exited with error code "%s" and response %s.', $ret, PHP_EOL . implode(PHP_EOL, $response)));
   }
 
   return $response;
+}
+
+/**
+ * Check if tests are running in debug mode.
+ */
+function is_debug() {
+  return in_array('--debug', $_SERVER['argv'], TRUE);
 }

--- a/.docker/images/nginx/tests/composer.json
+++ b/.docker/images/nginx/tests/composer.json
@@ -2,6 +2,7 @@
     "name": "govcmstests/nginx",
     "description": "Testing framework for the nginx image.",
     "type": "project",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Steve Worley",

--- a/.docker/images/nginx/tests/src/BlocksTest.php
+++ b/.docker/images/nginx/tests/src/BlocksTest.php
@@ -7,8 +7,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Ensure that the blocks are respected by nginx.
  */
-class BlocksTest extends TestCase
-{
+class BlocksTest extends TestCase {
 
   /**
    * Aggressive bots.
@@ -16,8 +15,7 @@ class BlocksTest extends TestCase
    * @return array
    *   List of user agents.
    */
-  public function provideAggressiveAgents()
-  {
+  public function providerAggressiveAgents() {
     return [
       ['8LEGS'],
       // ['AhfresBot'], # This 500s?
@@ -39,8 +37,7 @@ class BlocksTest extends TestCase
    * @return array
    *    List of user agents.
    */
-  public function provideMicrosoftAgents()
-  {
+  public function providerMicrosoftAgents() {
     return [
       ['Skype.for.Business'],
       ['Microsoft.Office'],
@@ -53,8 +50,7 @@ class BlocksTest extends TestCase
    * @return array
    *   List of paths.
    */
-  public function provideWordpressPaths()
-  {
+  public function providerWordpressPaths() {
     return [
       ['/wp-admin'],
       // ['/wp-admin/index.php'], # 500s
@@ -75,8 +71,7 @@ class BlocksTest extends TestCase
    * @return array
    *    List of query strings.
    */
-  public function provideQueryStrings()
-  {
+  public function providerQueryStrings() {
     return [
       ['?q=node/add'],
       ['?q=user/register'],
@@ -86,10 +81,9 @@ class BlocksTest extends TestCase
   /**
    * Ensure that aggressive bots are blocked.
    *
-   * @dataProvider provideAggressiveAgents
+   * @dataProvider providerAggressiveAgents
    */
-  public function testAggressiveCrawlerBlock($ua)
-  {
+  public function testAggressiveCrawlerBlock($ua) {
     $headers = \get_curl_headers("/", "--user-agent '{$ua}'");
     $this->assertEquals(403, $headers['Status']);
   }
@@ -97,10 +91,9 @@ class BlocksTest extends TestCase
   /**
    * Ensure that Microsofts home check is prevented.
    *
-   * @dataProvider provideMicrosoftAgents
+   * @dataProvider providerMicrosoftAgents
    */
-  public function testMicrosoftHomeCall($ua)
-  {
+  public function testMicrosoftHomeCall($ua) {
     $headers = \get_curl_headers("/", "--user-agent '{$ua}'");
     $this->assertEquals(403, $headers['Status']);
   }
@@ -108,8 +101,7 @@ class BlocksTest extends TestCase
   /**
    * Ensure the autodiscover.xml files are restricted.
    */
-  public function testAutodiscover()
-  {
+  public function testAutodiscover() {
     $headers = \get_curl_headers("/autodiscover.xml");
     $this->assertEquals(403, $headers['Status']);
   }
@@ -117,10 +109,9 @@ class BlocksTest extends TestCase
   /**
    * Ensure that wordpress-like paths are blocked.
    *
-   * @dataProvider provideWordpressPaths
+   * @dataProvider providerWordpressPaths
    */
-  public function testWordpressAttacks($path)
-  {
+  public function testWordpressAttacks($path) {
     $headers = \get_curl_headers($path);
     $this->assertEquals(403, $headers['Status']);
   }
@@ -128,11 +119,11 @@ class BlocksTest extends TestCase
   /**
    * Ensure common query strings vectors are restricted.
    *
-   * @dataProvider provideQueryStrings
+   * @dataProvider providerQueryStrings
    */
-  public function testQueryStringBlock($query)
-  {
+  public function testQueryStringBlock($query) {
     $headers = \get_curl_headers($query);
     $this->assertEquals(403, $headers['Status']);
   }
+
 }

--- a/.docker/images/nginx/tests/src/FilesCacheTest.php
+++ b/.docker/images/nginx/tests/src/FilesCacheTest.php
@@ -4,8 +4,18 @@ namespace GovCMSTests;
 
 use PHPUnit\Framework\TestCase;
 
-class FilesCacheTest extends TestCase
-{
+class FilesCacheTest extends TestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    `docker-compose exec nginx mkdir -p /app/sites/default/files`;
+    foreach ($this->providerExpiredHeaderPath() as $parts) {
+      list($file, $path) = $parts;
+      `docker cp $path/$file $(docker-compose ps -q nginx):/app/web/sites/default/files/`;
+    }
+  }
 
   /**
    * Return a list of files to test.
@@ -13,37 +23,24 @@ class FilesCacheTest extends TestCase
    * @return array
    *   File list.
    */
-  public function filesProvider()
-  {
+  public function providerExpiredHeaderPath() {
     $path = dirname(__DIR__);
     return [
-      ["autotest.jpg", "$path/resources/", 'max-age=2628001'],
-      ["autotest.pdf", "$path/resources/", 'max-age=1800'],
-      ["autotest.rtf", "$path/resources/", 'max-age=2628001'],
+      ['autotest.jpg', "$path/resources/", 'max-age=2628001'],
+      ['autotest.pdf', "$path/resources/", 'max-age=1800'],
+      ['autotest.rtf', "$path/resources/", 'max-age=2628001'],
     ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function setUp(): void
-  {
-    `docker-compose exec nginx mkdir -p /app/sites/default/files`;
-    foreach ($this->filesProvider() as $parts) {
-      list($file, $path) = $parts;
-      `docker cp $path/$file $(docker-compose ps -q nginx):/app/web/sites/default/files/`;
-    }
   }
 
   /**
    * Ensure that expires headers are correctly set.
    *
-   * @dataProvider filesProvider
+   * @dataProvider providerExpiredHeaderPath
    */
-  public function testHeader($file, $path, $expected)
-  {
+  public function testExpiredHeaderPath($file, $path, $expected) {
     $path = "/sites/default/files/$file";
     $headers = \get_curl_headers($path);
     $this->assertEquals($expected, $headers['Cache-Control']);
   }
+
 }

--- a/.docker/images/nginx/tests/src/FrameOptionsTest.php
+++ b/.docker/images/nginx/tests/src/FrameOptionsTest.php
@@ -7,15 +7,14 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test frame options from the request.
  */
-class FrameOptionsTest extends TestCase
-{
+class FrameOptionsTest extends TestCase {
 
   /**
    * Ensure that the X-Frame-Option header is present.
    */
-  public function testHeaderExists()
-  {
-    $headers = \get_curl_headers("/");
+  public function testHeaderExists() {
+    $headers = \get_curl_headers('/');
     $this->assertEquals('SameOrigin', $headers['X-Frame-Options']);
   }
+
 }

--- a/.docker/images/nginx/tests/src/PrivateFilesTest.php
+++ b/.docker/images/nginx/tests/src/PrivateFilesTest.php
@@ -7,33 +7,15 @@ use PHPUnit\Framework\TestCase;
 /**
  * Ensure that the private files are restricted.
  */
-class PrivateFilesTest extends TestCase
-{
-
-  /**
-   * Return a list of files to test.
-   *
-   * @return array
-   *    File list.
-   */
-  public function filesProvider()
-  {
-    $path = dirname(__DIR__);
-    return [
-      ["autotest.jpg", "$path/resources/"],
-      ["autotest.pdf", "$path/resources/"],
-      ["autotest.rtf", "$path/resources/"],
-    ];
-  }
+class PrivateFilesTest extends TestCase {
 
   /**
    * {@inheritdoc}
    */
-  public function setUp(): void
-  {
+  public function setUp(): void {
     // Make sure private files directory exists in the nginx container.
     `docker-compose exec nginx mkdir -p /app/web/sites/default/files/private`;
-    foreach ($this->filesProvider() as $parts) {
+    foreach ($this->providerFileAccess() as $parts) {
       list($file, $path) = $parts;
       // Move out test files.
       `docker cp $path/$file $(docker-compose ps -q nginx):/app/web/sites/default/files/private/`;
@@ -41,14 +23,29 @@ class PrivateFilesTest extends TestCase
   }
 
   /**
+   * Return a list of files to test.
+   *
+   * @return array
+   *    File list.
+   */
+  public function providerFileAccess() {
+    $path = dirname(__DIR__);
+    return [
+      ['autotest.jpg', "$path/resources/"],
+      ['autotest.pdf', "$path/resources/"],
+      ['autotest.rtf', "$path/resources/"],
+    ];
+  }
+
+  /**
    * Ensure that private files are restricted.
    *
-   * @dataProvider filesProvider
+   * @dataProvider providerFileAccess
    */
-  public function testFileAccess($file)
-  {
+  public function testFileAccess($file) {
     $path = "/sites/default/files/private/$file";
     $headers = \get_curl_headers($path);
     $this->assertEquals(404, $headers['Status'], "[$path] is publicly accessible");
   }
+
 }

--- a/.docker/images/nginx/tests/src/RobotsTagTest.php
+++ b/.docker/images/nginx/tests/src/RobotsTagTest.php
@@ -7,8 +7,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Ensure that bots are not allowed.
  */
-class RobotsTagTest extends TestCase
-{
+class RobotsTagTest extends TestCase {
 
   /**
    * Provide a list of blocked host names.
@@ -16,8 +15,7 @@ class RobotsTagTest extends TestCase
    * @return array
    *   A list of invalid host names.
    */
-  public function provideInvalidHosts()
-  {
+  public function providerInvalidHosts() {
     return [
       ['test.govcms.gov.au'],
       ['wsa.govcms.gov.au'],
@@ -33,8 +31,7 @@ class RobotsTagTest extends TestCase
    * @return array
    *   An array of valid domains.
    */
-  public function provideValidHosts()
-  {
+  public function providerValidHosts() {
     return [
       ['test.gov.au'],
       ['betahealth-sr.gov.au'],
@@ -45,11 +42,10 @@ class RobotsTagTest extends TestCase
   /**
    * Ensure that the X-Robots-Tag is set to none.
    *
-   * @dataProvider provideInvalidHosts
+   * @dataProvider providerInvalidHosts
    */
-  public function testXRobotsNone($host)
-  {
-    $headers = \get_curl_headers("/", "-H 'Host: $host'");
+  public function testXRobotsNone($host) {
+    $headers = \get_curl_headers('/', "-H 'Host: $host'");
     $this->assertArrayHasKey('X-Robots-Tag', $headers);
     $this->assertEquals('none', $headers['X-Robots-Tag']);
   }
@@ -57,12 +53,12 @@ class RobotsTagTest extends TestCase
   /**
    * Ensure that X-Robots-Tag is set to all.
    *
-   * @dataProvider provideValidHosts
+   * @dataProvider providerValidHosts
    */
-  public function testXRobotsAll($host)
-  {
-    $headers = \get_curl_headers("/", "-H 'Host: $host'");
+  public function testXRobotsAll($host) {
+    $headers = \get_curl_headers('/', "-H 'Host: $host'");
     $this->assertArrayHasKey('X-Robots-Tag', $headers);
     $this->assertEquals('all', $headers['X-Robots-Tag']);
   }
+
 }

--- a/.docker/images/nginx/tests/src/RobotsTxtTest.php
+++ b/.docker/images/nginx/tests/src/RobotsTxtTest.php
@@ -7,11 +7,15 @@ use PHPUnit\Framework\TestCase;
 /**
  * Ensure that bots are not allowed.
  */
-class RobotsTxtTest extends TestCase
-{
+class RobotsTxtTest extends TestCase {
 
-  public function provideHosts()
-  {
+  /**
+   * List of disallowed hosts.
+   *
+   * @return array
+   *   Array of disallowed hosts.
+   */
+  public function providerDisallowedHosts() {
     return [
       ['test.govcms.gov.au'],
       ['wsa.govcms.gov.au'],
@@ -22,11 +26,11 @@ class RobotsTxtTest extends TestCase
   }
 
   /**
-   * Disallow in govcms.
-   * @dataProvider provideHosts
+   * Test that robots.txt returns correct Disallow directive for provided hosts.
+   *
+   * @dataProvider providerDisallowedHosts
    */
-  public function testDisallowString($host)
-  {
+  public function testDisallowedHosts($host) {
     $robots_txt = \curl_get_content('/robots.txt', "-H 'Host: $host'");
     $this->assertEquals('User-agent: *', $robots_txt[0]);
     $this->assertEquals('Disallow: /', $robots_txt[1]);
@@ -35,11 +39,13 @@ class RobotsTxtTest extends TestCase
   /**
    * Govcms skips.
    */
-  public function testGovcmsSkips()
-  {
-    // Drupal is configured to respond to robots.txt as well as we're adding X-Robots-Tag to all Drupal requests.
-    // We ensure that X-Robots-Tag is added to the response as this means Drupal is serving the request.
+  public function testGovcmsSkips() {
+    // Drupal is configured to respond to robots.txt as well as we're
+    // adding "X-Robots-Tag" to all Drupal requests.
+    // We ensure that "X-Robots-Tag" is added to the response as this means
+    // that Drupal is serving the request.
     $robots_headers = \get_curl_headers('/robots.txt', "-H 'Host: www.govcms.gov.au'");
     $this->assertArrayHasKey('X-Robots-Tag', $robots_headers);
   }
+
 }

--- a/.docker/images/nginx/tests/src/RobotsTxtTest.php
+++ b/.docker/images/nginx/tests/src/RobotsTxtTest.php
@@ -23,14 +23,13 @@ class RobotsTxtTest extends TestCase
 
   /**
    * Disallow in govcms.
-   *
    * @dataProvider provideHosts
    */
   public function testDisallowString($host)
   {
-    $robots_txt = \curl_get_content("/robots.txt", "-H 'Host: $host'");
-    $this->assertEquals($robots_txt[0], "User-agent: *");
-    $this->assertEquals($robots_txt[1], 'Disallow: /');
+    $robots_txt = \curl_get_content('/robots.txt', "-H 'Host: $host'");
+    $this->assertEquals('User-agent: *', $robots_txt[0]);
+    $this->assertEquals('Disallow: /', $robots_txt[1]);
   }
 
   /**
@@ -40,7 +39,7 @@ class RobotsTxtTest extends TestCase
   {
     // Drupal is configured to respond to robots.txt as well as we're adding X-Robots-Tag to all Drupal requests.
     // We ensure that X-Robots-Tag is added to the response as this means Drupal is serving the request.
-    $robots_headers = get_curl_headers("/robots.txt", "-H 'Host: www.govcms.gov.au'");
+    $robots_headers = \get_curl_headers('/robots.txt', "-H 'Host: www.govcms.gov.au'");
     $this->assertArrayHasKey('X-Robots-Tag', $robots_headers);
   }
 }

--- a/.docker/images/nginx/tests/src/SecurityHeadersTest.php
+++ b/.docker/images/nginx/tests/src/SecurityHeadersTest.php
@@ -7,14 +7,12 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test frame options from the request.
  */
-class SecurityHeadersTest extends TestCase
-{
+class SecurityHeadersTest extends TestCase {
 
   /**
    * Ensure that the X-XSS-Protection header is present.
    */
-  public function testXssProtectioin()
-  {
+  public function testXssProtectioin() {
     $headers = \get_curl_headers("/");
     $this->assertEquals('1; mode=block', $headers['X-XSS-Protection']);
   }
@@ -22,8 +20,7 @@ class SecurityHeadersTest extends TestCase
   /**
    * Ensure taht the X-Content-Type-Options header is prsent.
    */
-  public function testContentTypeOptions()
-  {
+  public function testContentTypeOptions() {
     $headers = \get_curl_headers("/");
     $this->assertEquals('nosniff', $headers['X-Content-Type-Options']);
   }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,8 +164,15 @@ test:nginx:
   <<: *test
   stage: test
   script:
-    - docker-compose exec -T nginx nginx -t
+    # Wait for nginx container.
+    - docker-compose exec test dockerize -wait tcp://nginx:8080 -timeout 1m
+    # Validate nginx configuration.
+    - docker-compose exec nginx nginx -t
+    # Validate composer.json and composer.lock configuration for tests.
+    - composer validate --strict -d .docker/images/nginx/tests
+    # Install dependencies for tests.
     - composer install -d .docker/images/nginx/tests
+    # Run tests and store logs in artifacts directory.
     - .docker/images/nginx/tests/vendor/bin/phpunit -c .docker/images/nginx/tests/phpunit.xml
   needs:
     - build:containers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,9 +165,9 @@ test:nginx:
   stage: test
   script:
     # Wait for nginx container.
-    - docker-compose exec test dockerize -wait tcp://nginx:8080 -timeout 1m
+    - docker-compose exec -T test dockerize -wait tcp://nginx:8080 -timeout 1m
     # Validate nginx configuration.
-    - docker-compose exec nginx nginx -t
+    - docker-compose exec -T nginx nginx -t
     # Validate composer.json and composer.lock configuration for tests.
     - composer validate --strict -d .docker/images/nginx/tests
     # Install dependencies for tests.


### PR DESCRIPTION
## Changes
- Fixed `nginx` URL in tests to only use URI accessible within containers. 
**Note that this change is required to correctly handle newer versions of Docker Compose (which reads variables from .env) - this will be available to check in another PR when we update CI container image with new version of Docker and Docker Compose.**
- Updated PHPunit helpers to use verbose output when `--debug` is provided for tests.
- Fixed coding standards in all tests to follow Drupal coding standards.
- Updated CircleCI CI config to wait for `nginx` container and check for `composer.json` validity.
- Updated GitLab CI config to wait for `nginx` container and check for `composer.json` validity.
- Removed pushing of Docker images from CircleCI as this is now handled in GitLab.

Please see inline comments for more information.

**Similar PR will be raised in https://github.com/govCMS/govcmslagoon repository.**