### PR TITLE
Add timeout to Redis connect

### DIFF
--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -179,9 +179,13 @@ if (getenv('LAGOON') && (getenv('ENABLE_REDIS'))) {
       throw new \Exception('Drupal installation underway.');
     }
 
-    $redis->connect($redis_host, $redis_port);
+    # Use a timeout to ensure that if Redis is down, that Drupal will
+    # continue to function.
+    if ($redis->connect($redis_host, $redis_port, 1) === FALSE) {
+      throw new \Exception('Redis server unreachable.');
+    }
+    
     $response = $redis->ping();
-
     if (strpos($response, 'PONG') === FALSE) {
       throw new \Exception('Redis could be reached but is not responding correctly.');
     }


### PR DESCRIPTION
At the moment, there is no timeout for Redis, which means that Drupal will wait forever to Redis to become available. This can and has lead to site outages where Redis has been under immense load. 

Comprehensive testing done in https://github.com/amazeeio/drupal-example/pull/70#issuecomment-611589542
