### PR TITLE
Updated environment indicator colours (AAA WCAG).

### DIFF
--- a/.docker/images/govcms8/settings/development.settings.php
+++ b/.docker/images/govcms8/settings/development.settings.php
@@ -46,9 +46,6 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/default/development.servi
 /**
  * Configure Environment indicator.
  */
-$config['environment_indicator.indicator']['bg_color'] = 'green';
-$config['environment_indicator.indicator']['name'] = 'Branch Development';
-
-if (getenv('LOCALDEV_URL') !== FALSE) {
-  $config['environment_indicator.indicator']['name'] = 'Local Development';
-}
+$config['environment_indicator.indicator']['bg_color'] = '#006600';
+$config['environment_indicator.indicator']['fg_color'] = '#FFFFFF';
+$config['environment_indicator.indicator']['name'] = 'Non-production';

--- a/.docker/images/govcms8/settings/production.settings.php
+++ b/.docker/images/govcms8/settings/production.settings.php
@@ -29,16 +29,9 @@ $config['system.performance']['js']['preprocess'] = 1;
 $config['stage_file_proxy.settings']['origin'] = false;
 
 // Configure Environment indicator.
-$config['environment_indicator.indicator']['bg_color'] = 'red';
-$config['environment_indicator.indicator']['name'] = 'Public Domain';
-
-if (!empty($_SERVER['HTTP_HOST'])) {
-  $http_host = $_SERVER['HTTP_HOST'];
-  if (preg_match('/(?<!www)\.govcms\.gov\.au/i', $http_host)) {
-    $config['environment_indicator.indicator']['bg_color'] = 'orange';
-    $config['environment_indicator.indicator']['name'] = 'Edit Domain';
-  }
-}
+$config['environment_indicator.indicator']['bg_color'] = '#AF110E';
+$config['environment_indicator.indicator']['fg_color'] = '#FFFFFF';
+$config['environment_indicator.indicator']['name'] = 'Production';
 
 // Disable temporary file deletion (GOVCMSD8-576).
 $config['system.file']['temporary_maximum_age'] = 0;


### PR DESCRIPTION
Simplifies the `environment_indicator` SaaS setup:
* Only differentiate between prod and non-prod
* Use WCAG AAA compliant colours

<img width="483" alt="Screen Shot 2020-05-19 at 12 00 54 pm" src="https://user-images.githubusercontent.com/1256274/82270881-55ca8280-99ca-11ea-9de3-2e7b5b4f70b7.png">
<img width="484" alt="Screen Shot 2020-05-19 at 11 39 56 am" src="https://user-images.githubusercontent.com/1256274/82270882-57944600-99ca-11ea-8dc0-3ffc303094b3.png">
