### PR TITLE
Remove --database option from sqlc-sync.

### DIFF
--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -22,7 +22,7 @@ dev_config_count=`ls -1 /app/config/dev/*.yml 2>/dev/null | wc -l`
 
 # Database options to configure the remote to use the read replica when
 # performing read operations.
-sync_opts=""
+dump_opts=""
 read_replica_enabled () {
   if [[ -z "$MARIADB_READREPLICA_HOSTS" ]]; then
     return
@@ -30,7 +30,7 @@ read_replica_enabled () {
 
   if tables=$(drush @govcms.prod sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
     echo "Replica is available, using for database operations."
-    sync_opts="--source-database=read"
+    dump_opts="--database=read"
   fi
 }
 
@@ -55,9 +55,6 @@ common_deploy () {
 
 # Non production environments.
 if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
-
-    read_replica_enabled $sync_opts
-
     if ! drush status --fields=bootstrap | grep -q "Successful"; then
         # Import prod db in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
@@ -79,7 +76,9 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
 # Production environments.
 else
   if drush status --fields=bootstrap | grep -q "Successful"; then
-    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql $sync_opts
+    read_replica_enabled $dump_opts
+
+    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql $dump_opts
     drush config-export sync -y --destination /app/web/sites/default/files/private/backups/config && tar -czf /app/web/sites/default/files/private/backups/config.tar.gz -C /app/web/sites/default/files/private/backups/config . && rm -rf /app/web/sites/default/files/private/backups/config
     common_deploy
     drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;

--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -62,7 +62,7 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
         # Import prod db in Lagoon development environments.
         if [[ ! -z "$LAGOON_ENVIRONMENT_TYPE" && "$LAGOON_ENVIRONMENT_TYPE" != "local" ]]; then
           drush sql-drop -y
-          drush sql-sync @govcms.prod @self $sync_opts -y
+          drush sql-sync @govcms.prod @self -y
           common_deploy
         else
           echo "Drupal not installed."
@@ -72,14 +72,14 @@ if [[ "$LAGOON_ENVIRONMENT_TYPE" != "production" ]]; then
       if [[ "$GOVCMS_TEST_CANARY" = TRUE ]]; then
         echo "GOVCMS_TEST_CANARY is set, syncing the database."
         drush sql-drop -y
-        drush sql-sync @govcms.prod @self $sync_opts -y
+        drush sql-sync @govcms.prod @self -y
       fi
       common_deploy
     fi
 # Production environments.
 else
   if drush status --fields=bootstrap | grep -q "Successful"; then
-    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql
+    mkdir -p /app/web/sites/default/files/private/backups/ && drush sql-dump --gzip --result-file=/app/web/sites/default/files/private/backups/pre-deploy-dump.sql $sync_opts
     drush config-export sync -y --destination /app/web/sites/default/files/private/backups/config && tar -czf /app/web/sites/default/files/private/backups/config.tar.gz -C /app/web/sites/default/files/private/backups/config . && rm -rf /app/web/sites/default/files/private/backups/config
     common_deploy
     drush en -y govcms_lagoon && drush pmu -y govcms_lagoon;

--- a/.docker/images/govcms8/scripts/govcms-deploy
+++ b/.docker/images/govcms8/scripts/govcms-deploy
@@ -28,7 +28,7 @@ read_replica_enabled () {
     return
   fi
 
-  if tables=$(drush @govcms.prod sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
+  if tables=$(drush sqlq 'show tables;' --database=read 2> /dev/null) && [ -n "$tables" ]; then
     echo "Replica is available, using for database operations."
     dump_opts="--database=read"
   fi


### PR DESCRIPTION
- Drush 9 is included and incompatible with --database on sql-sync.