### PR TITLE
[Govcmsd8-689] Harden hash_salt value in settings.php

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -44,6 +44,7 @@ RUN mkdir -p /app/web/sites/default/files/private \
 COPY modules/ /app/web/sites/all/modules/
 
 COPY .docker/images/govcms8/settings/ /app/web/sites/default/
+RUN /usr/bin/govcms-setting new-site-salt
 RUN chmod 444 /app/web/sites/default/settings.php
 
 # Define where the Drupal Root is located

--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -27,6 +27,7 @@ COPY .docker/sanitize.sh /app/sanitize.sh
 
 COPY .docker/images/govcms8/scripts /usr/bin/
 RUN chmod 755 /usr/bin/govcms-deploy
+RUN chmod 755 /usr/bin/govcms-setting
 COPY .docker/images/govcms8/govcms.site.yml /app/drush/sites/
 
 # Ensure MySQL client can accept server max_allowed_packet

--- a/.docker/images/govcms8/scripts/govcms-setting
+++ b/.docker/images/govcms8/scripts/govcms-setting
@@ -6,7 +6,7 @@
 # Set a new randome hash salt
 if [ "$1" = "new-site-salt" ]; then
 	: ${SITE_HASH_SALT:=$(drush php-eval -q 'echo \Drupal\Component\Utility\Crypt::randomBytesBase64(55) . "\n";')}
-	sed -ri -e "s@^\\\$settings\['hash_salt'\] = .+;@\\\$settings\['hash_salt'\] = '$SITE_HASH_SALT';@g" /app/web/sites/default/settings.php
+	sed -ri -e "s@^\s*\\\$settings\['hash_salt'\] = .+;@  \\\$settings\['hash_salt'\] = '$SITE_HASH_SALT';@g" /app/web/sites/default/settings.php
 fi
 
 

--- a/.docker/images/govcms8/scripts/govcms-setting
+++ b/.docker/images/govcms8/scripts/govcms-setting
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+##
+# Govcms setting script.
+#
+
+# Set a new randome hash salt
+if [ "$1" = "new-site-salt" ]; then
+	: ${SITE_HASH_SALT:=$(drush php-eval -q 'echo \Drupal\Component\Utility\Crypt::randomBytesBase64(55) . "\n";')}
+	sed -ri -e "s@^\\\$settings\['hash_salt'\] = .+;@\\\$settings\['hash_salt'\] = '$SITE_HASH_SALT';@g" /app/web/sites/default/settings.php
+fi
+
+


### PR DESCRIPTION
Introduce a new script to generate a URL-safe, base64 encoded string of highly randomized hash salt in the way that Drupal does during installation.
The new command is:
docker-compose exec cli govcms-setting new-site-salt

The new script will be run as part of the building process.