### PR TITLE
Changes for release v8.9.6

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,8 +43,8 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.8
-DRUPAL_CORE_VERSION=8.9.3
+GOVCMS_PROJECT_VERSION=1.9.0
+DRUPAL_CORE_VERSION=8.9.6
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v1.2.0)
 # See https://github.com/amazeeio/lagoon/releases


### PR DESCRIPTION
Release 8.9.6 will be tagged on this commit hash upon approval.
This release is only to include the changes to Drupal core in the GovCMS distribution.

Changes which have been merged into `develop` after release 8.9.3 are planned for inclusion in the next release which will come with the next distribution release.