### PR TITLE
Added yq/jq binaries for pre-deploy validation scripts.

### DIFF
--- a/.docker/Dockerfile.govcms8
+++ b/.docker/Dockerfile.govcms8
@@ -10,6 +10,14 @@ ARG GITHUB_TOKEN
 
 COPY composer.* /app/
 
+# Install yq for YAML parsing.
+RUN wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64" \
+  && chmod +x /usr/local/bin/yq
+
+# Install jq for JSON parsing.
+RUN wget -O /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64" \
+  && chmod +x /usr/local/bin/jq
+
 RUN sed -i -e "/govcms\/govcms/ s!\^1.0!${GOVCMS_PROJECT_VERSION}!" /app/composer.json \
     && sed -i -e "/drupal\/core-recommended/ s!\^8.8!${DRUPAL_CORE_VERSION}!" /app/composer.json
 


### PR DESCRIPTION
As per https://github.com/govCMS/govcms-ci/blob/master/govcms-ci.Dockerfile#L39

Adds binaries required for pre-deploy validation scripts.