### PR TITLE
Enable GC override.

### DIFF
--- a/.docker/images/govcms8/settings/production.settings.php
+++ b/.docker/images/govcms8/settings/production.settings.php
@@ -35,3 +35,6 @@ $config['environment_indicator.indicator']['name'] = 'Production';
 
 // Disable temporary file deletion (GOVCMSD8-576).
 $config['system.file']['temporary_maximum_age'] = 0;
+if (is_numeric($image_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {
+  $config['system.file']['temporary_maximum_age'] = $image_gc;
+}

--- a/.docker/images/govcms8/settings/production.settings.php
+++ b/.docker/images/govcms8/settings/production.settings.php
@@ -35,6 +35,6 @@ $config['environment_indicator.indicator']['name'] = 'Production';
 
 // Disable temporary file deletion (GOVCMSD8-576).
 $config['system.file']['temporary_maximum_age'] = 0;
-if (is_numeric($image_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {
-  $config['system.file']['temporary_maximum_age'] = $image_gc;
+if (is_numeric($file_gc = getenv('GOVCMS_FILE_TEMP_MAX_AGE'))) {
+  $config['system.file']['temporary_maximum_age'] = $file_gc;
 }


### PR DESCRIPTION
- Adds the GOVCMS_FILE_TEMP_MAX_AGE environment variable to allow support agents to enable temporary file GC.