### PR TITLE
[GOVCMSD8-765] Make the HTTP Client request timeout configurable.

### DIFF
--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -271,6 +271,11 @@ if (getenv('LAGOON')) {
   }
 }
 
+// Allow setting a higher timeout value for HTTP Client requests (default: 30 seconds).
+if (is_numeric($http_client_timeout = getenv('GOVCMS_HTTP_CLIENT_TIMEOUT'))) {
+  $settings['http_client_config']['timeout'] = $http_client_timeout;
+}
+
 // Enforce correct solr server configuration (GOVCMS-4634)
 // Fix for 8.5.0 and the solr upgrade.
 $config['search_api.server.lagoon_solr']['backend_config']['connector_config']['path'] = '/';

--- a/.docker/images/govcms8/settings/settings.php
+++ b/.docker/images/govcms8/settings/settings.php
@@ -271,9 +271,17 @@ if (getenv('LAGOON')) {
   }
 }
 
-// Allow setting a higher timeout value for HTTP Client requests (default: 30 seconds).
-if (is_numeric($http_client_timeout = getenv('GOVCMS_HTTP_CLIENT_TIMEOUT'))) {
-  $settings['http_client_config']['timeout'] = $http_client_timeout;
+// Allow projects to increase the HTTP client timeout for CLI requests.
+// This will impact migrations that rely on external services and other
+// HTTP requests that the Drupal request library makes.
+//
+// This has only been added to affect CLI because this timeout can hold
+// PHP processes if a remote request is unavailable, as sites can do
+// inline HTTP requests this is a performance risk.
+if (defined('STDIN') || in_array(PHP_SAPI, ['cli', 'cli-server'])) {
+  if (is_numeric($http_client_timeout = getenv('GOVCMS_HTTP_CLIENT_TIMEOUT'))) {
+    $settings['http_client_config']['timeout'] = $http_client_timeout;
+  }
 }
 
 // Enforce correct solr server configuration (GOVCMS-4634)


### PR DESCRIPTION
The current default HTTP client timeout is 30 seconds which can be insufficient in some cases (e.g. importing external data using Migrate module).