### PR TITLE
Release 8.9.11

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,8 +43,8 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.12.0
-DRUPAL_CORE_VERSION=8.9.9
+GOVCMS_PROJECT_VERSION=1.13.0
+DRUPAL_CORE_VERSION=8.9.11
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. v1.2.0)
 # See https://github.com/amazeeio/lagoon/releases


### PR DESCRIPTION
### Release notes

- Pin GovCMS version to 1.13.0 
- Pin  Drupal core to 8.9.11
- [GOVCMSD8-776]: Remove except schedules https://github.com/govCMS/govcms8lagoon/pull/189