### PR TITLE
[GOVCMS-5600] Use the internal docker registry.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,8 @@
 ---
-
-image: govcms/govcms-ci:latest
+image: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci${GOVCMS_CI_IMAGE_VERSION}
 
 services:
-  - "docker:dind"
+  - gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
 
 stages:
   - validate


### PR DESCRIPTION
Switches CI to the internal docker registry. 