### PR TITLE
[GOVCMS-5619]: Add amazeeio domains to non-prod robots ignore.

### DIFF
--- a/.docker/images/nginx/helpers/200-no_robots_govcms_host.conf
+++ b/.docker/images/nginx/helpers/200-no_robots_govcms_host.conf
@@ -3,8 +3,12 @@
 if ($uri = "/robots.txt"){
   set $robots_disallow_test "isRobotstxtURI";
 }
-# matches *.govcms.gov.au (also multiple subdomains) except www.govcms.gov.au
-if ($host ~* ^(?!www\.govcms\.gov\.au$)(?:[\w\-]+\.)+govcms\.gov\.au$){
+
+# matches *.govcms.gov.au (multiple subdomains)
+# matches *.govcms.amazee.io (multiple subdomains)
+#
+# Excludes matching on www.govcms.gov.au
+if ($host ~* ^(?!www\.govcms\.gov\.au$)(?:[\w\-]+\.)+govcms\.(gov\.au|amazee\.io)$){
   set $robots_disallow_test "$robots_disallow_test+isGovcmsHost";
 }
 

--- a/.docker/images/nginx/tests/src/RobotsTxtTest.php
+++ b/.docker/images/nginx/tests/src/RobotsTxtTest.php
@@ -22,6 +22,7 @@ class RobotsTxtTest extends TestCase {
       ['multi.subdomain.govcms.gov.au'],
       ['www2.govcms.gov.au'],
       ['test.govcms.gov.au'],
+      ['test.govcms.amazee.io'],
     ];
   }
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,8 @@
 image: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci${GOVCMS_CI_IMAGE_VERSION}
 
 services:
-  - gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
+  - name: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
+    command: ["--tls=false"]
 
 stages:
   - validate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ stages:
   IMAGE_VERSION_TAG_PREFIX: ""
   IMAGE_VERSION_TAG: ""
   IMAGE_TAG_EDGE: $CI_COMMIT_SHA
+  DOCKER_HOST: tcp://localhost:2375
 
 .test: &test
   variables:


### PR DESCRIPTION
- Adds *.govcms.amazee.io to the ignore robots.txt regex

eg.

```
$ http https://nginx-ipaustralia-feature-ipa-dev.govcms.amazee.io/robots.txt

User-agent: *
Crawl-delay: 10
# Directories

Disallow: /includes/
```

After change:
```
$ http https://nginx-ipaustralia-feature-ipa-dev.govcms.amazee.io/robots.txt

User-agent: *
Disallow: /
```