### PR TITLE
[GOVCMS-5035] Build both legacy/new container names.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,11 +80,33 @@ validate:containers:
   script:
     - docker-compose config -q
 
+##
+## Legacy images are built as govcms8lagoon/govcms8.
+##
+build:legacy-containers:
+  variables:
+    <<: *vars
+    DOCKER_REGISTRY_HOST: $CI_REGISTRY/
+    DOCKERHUB_NAMESPACE: govcms8lagoon
+    GOVCMS_CLI_IMAGE_NAME: govcms8
+  stage: build
+  before_script:
+    - *before_script_common
+  script:
+    # @TODO: Re-instate container caching.
+    # - docker login -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD} ${CI_REGISTRY}
+    - docker network prune -f && docker network inspect amazeeio-network >/dev/null || docker network create amazeeio-network
+    - ahoy -v build
+    - docker-compose exec -T test dockerize -wait tcp://mariadb:3306 -timeout 1m
+    # @TODO: Re-instate container caching.
+    # - .docker/push.sh
+
 build:containers:
   variables:
     <<: *vars
     DOCKER_REGISTRY_HOST: $CI_REGISTRY/
-    DOCKERHUB_NAMESPACE: dof-dev/govcms8lagoon
+    DOCKERHUB_NAMESPACE: govcms
+    GOVCMS_CLI_IMAGE_NAME: govcms
   stage: build
   before_script:
     - *before_script_common
@@ -192,7 +214,7 @@ test:drupal_versions:
     paths:
       - $CSV_LOCATION
 
-deploy:edge:
+deploy:legacy-edge:
   <<: *deploy
   variables:
     <<: *vars
@@ -202,15 +224,28 @@ deploy:edge:
   only:
     - develop
 
-deploy:beta:
+deploy:legacy-beta:
   <<: *deploy
   variables:
     <<: *vars
     IMAGE_TAG_EDGE: beta
     DOCKERHUB_NAMESPACE: "govcms8lagoon"
     COMPOSE_PROJECT_NAME: "govcms8lagoon"
+    GOVCMS_CLI_IMAGE_NAME: "govcms8"
   only:
     - master
+
+deploy:8-edge:
+  <<: *deploy
+  variables:
+    <<: *vars
+    IMAGE_TAG_EDGE: 8.x-edge
+    DOCKERHUB_NAMESPACE: "govcms"
+    COMPOSE_PROJECT_NAME: "govcmslagoon"
+    GOVCMS_CLI_IMAGE_NAME: "govcms"
+  only:
+    - develop
+    - 8.x
 
 # @TODO: Allow automatic deploys of latest and tags after
 # the process has been validated.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,6 +221,7 @@ deploy:legacy-edge:
     IMAGE_TAG_EDGE: edge
     DOCKERHUB_NAMESPACE: "govcms8lagoon"
     COMPOSE_PROJECT_NAME: "govcms8lagoon"
+    GOVCMS_CLI_IMAGE_NAME: "govcms8"
   only:
     - develop
 


### PR DESCRIPTION
Deploy to both legacy/new dockerhub namespaces.

During transitionary phase from the `govcms8lagoon` to `govcms` namespace this will ensure that the nightly gitlab run will:
* Build legacy image names (`govcms8lagoon/govcms8:edge`)
* Build modern image names (`govcms/govcms:edge-8.x`)
* Push to dockerhub

This aligns to the CI pipeline in the `9.x` branch which does the same for GovCMS9 images.