### PR TITLE
Fix behat tests; disable w3c protocol.

### DIFF
--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -23,7 +23,7 @@ default:
       browser_name: chrome
       selenium2:
         wd_host: "http://chrome:4444/wd/hub"
-        capabilities: { "browser": "chrome", "version": "*", "marionette": true }
+        capabilities: { "browser": "chrome", "version": "*", "marionette": true, "extra_capabilities": { "chromeOptions": { "w3c": false } } }
       javascript_session: selenium2
     # Provides integration with Drupal APIs.
     Drupal\DrupalExtension:


### PR DESCRIPTION
Via @AlexSkrypnyk (https://medium.com/@alex.designworks/chromedriver-75-enforces-w3c-standard-breaking-behat-tests-460cad435545)
