### PR TITLE
[GOVCMSD9-41] New feature allow specify composer version

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -5,6 +5,7 @@ FROM uselagoon/php-7.4-cli-drupal:${LAGOON_IMAGE_VERSION} as builder
 ARG GOVCMS_PROJECT_VERSION
 ARG COMPOSER_AUTH
 ARG GITHUB_TOKEN
+ARG GOVCMS_COMPOSER_VERSION
 
 COPY composer.* /app/
 
@@ -27,7 +28,9 @@ ENV COMPOSER_MEMORY_LIMIT=-1
 # Set the Github OAuth token only when the variable is set.
 RUN [[ ! -z "${GITHUB_TOKEN}" ]]  && composer config -g github-oauth.github.com ${GITHUB_TOKEN} || echo "Personal Github OAuth token is not set."
 RUN composer global remove hirak/prestissimo \
-    && composer self-update \
+    && if [[ "${GOVCMS_COMPOSER_VERSION}" -eq 1 ]]; then GOVCMS_COMPOSER_VERSION="--1"; else if [[ "${GOVCMS_COMPOSER_VERSION}" -eq 2 ]]; then GOVCMS_COMPOSER_VERSION="--2"; fi; fi; \
+    composer self-update ${GOVCMS_COMPOSER_VERSION}\
+    && composer --version\
     && composer update -d /app \
     && composer clearcache
 

--- a/.env.default
+++ b/.env.default
@@ -48,3 +48,10 @@ LAGOON_IMAGE_VERSION=21.2.1
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.
 GOVCMS_CLI_IMAGE_NAME=govcms
+
+# Set the composer version
+# Ther version number could be one of following opotions:
+# 1. If the value is 1, composer will be updated to stable channel of version 1.
+# 2. If the value is 2, which is the default value, composer will be update to the stable channel of the version 2.
+# 3. A specific release number, for exmaple 1.10.20
+GOVCMS_COMPOSER_VERSION=2

--- a/.env.default
+++ b/.env.default
@@ -53,5 +53,5 @@ GOVCMS_CLI_IMAGE_NAME=govcms
 # Ther version number could be one of following opotions:
 # 1. If the value is 1, composer will be updated to stable channel of version 1.
 # 2. If the value is 2, which is the default value, composer will be update to the stable channel of the version 2.
-# 3. A specific release number, for exmaple 1.10.20
+# 3. A specific release number, for example 1.10.20
 GOVCMS_COMPOSER_VERSION=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
         COMPOSER_AUTH: ${COMPOSER_AUTH:-}
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+        GOVCMS_COMPOSER_VERSION: ${GOVCMS_COMPOSER_VERSION:-2}
     image: ${DOCKERHUB_NAMESPACE:-govcms8lagoon}/${GOVCMS_CLI_IMAGE_NAME:-govcms8}
     << : *default-volumes
     environment:


### PR DESCRIPTION
Introduce a new environment variable 'GOVCMS_COMPOSER_VERSION' to allow specifying the composer version while building a lagoon image.

It accepts three options:
 1. If the value is 1, composer will be updated to stable channel of version 1.
 2. If the value is 2, which is the default value, composer will be update to the stable channel of the version 2.
 3. A specific release number, for example 1.10.20