### PR TITLE
Ensure the containers are running

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,7 @@ info:modules:
     <<: *variables
   <<: *before_script_build
   script:
+    - ahoy up
     - ahoy -v install -- install_configure_form.update_status_module='array(FALSE,FALSE)'
     - docker-compose exec -T cli drush status
     - /govcms/vendor/bin/govcms-module_verify


### PR DESCRIPTION
Shared build script runs `ahoy build` which should bring the containers up, sometimes they are not available when the module info script is called resulting in a false positive failure. This adds a check to ensure that the containers are running prior to gathering module information.