### PR TITLE
Update the base images to reference the latest Lagoon images `21.4.0`

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=2.x-dev
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.2.1
+LAGOON_IMAGE_VERSION=21.3.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.

--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=2.x-dev
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.3.0
+LAGOON_IMAGE_VERSION=21.4.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
This change will incorporate

* https://github.com/uselagoon/lagoon-images/releases/tag/21.4.0
* https://github.com/uselagoon/lagoon-images/releases/tag/21.3.0
* https://github.com/uselagoon/lagoon-images/releases/tag/21.2.2

Which at a high level will update:

* Update Alpine Linux to `3.12.5`
* PHP to version `7.3.27` and `7.4.16`
* The opt-in ability to use Nginx `rewrite_log`
* Allow `crond` to use a non-root working directory
* Add Nginx map hash configuration