### PR TITLE
[draft] Release 9.1.2

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -27,7 +27,7 @@ ENV COMPOSER_MEMORY_LIMIT=-1
 # Set the Github OAuth token only when the variable is set.
 RUN [[ ! -z "${GITHUB_TOKEN}" ]]  && composer config -g github-oauth.github.com ${GITHUB_TOKEN} || echo "Personal Github OAuth token is not set."
 RUN composer global remove hirak/prestissimo \
-    && composer self-update \
+    && composer self-update --2 \
     && composer update -d /app \
     && composer clearcache
 

--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -1,8 +1,7 @@
 ARG CLI_IMAGE
-ARG LAGOON_IMAGE_VERSION
 FROM ${CLI_IMAGE} as cli
 
-FROM uselagoon/solr-7.7-drupal:${LAGOON_IMAGE_VERSION}
+FROM uselagoon/solr-7.7-drupal
 COPY --from=cli /app/web/modules/contrib/search_api_solr/solr-conf-templates/7.x/ /solr-conf/conf/
 
 USER root
@@ -10,10 +9,12 @@ RUN sed -i -e "s#<dataDir>\${solr.data.dir:}#<dataDir>/var/solr/\${solr.core.nam
     && sed -i -e "s#solr.lock.type:native#solr.lock.type:none#g" /solr-conf/conf/solrconfig.xml \
     && sed -i -e "s#solr.install.dir=../../..#solr.install.dir=/opt/solr#g" /solr-conf/conf/solrcore.properties
 
-RUN sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#8.3.8#g" /solr-conf/conf/schema.xml \
-    && sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#8.3.8#g" /solr-conf/conf/solrconfig.xml \
-    && sed -i -e "s#drupal-8.3.4#drupal-8.3.8#g" /opt/solr/server/solr/mycores/drupal/conf/schema.xml \
-    && sed -i -e "s#drupal-8.3.4#drupal-8.3.8#g" /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml
+RUN sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#4.1.1#g" /solr-conf/conf/schema.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_JUMP_START_CONFIG_SET#1#g" /solr-conf/conf/schema.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#4.1.1#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_JUMP_START_CONFIG_SET#1#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#drupal-8.3.8-solr-7.x#drupal-4.1.1-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/schema.xml \
+    && sed -i -e "s#drupal-8.3.8-solr-7.x#drupal-4.1.1-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml
 
 USER solr
 RUN precreate-core drupal /solr-conf/conf

--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=2.x-dev
+GOVCMS_PROJECT_VERSION=dev-release/2.x/2.0.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases

--- a/tests/goss/goss.solr.yaml
+++ b/tests/goss/goss.solr.yaml
@@ -7,7 +7,7 @@ file:
     exists: true
     filetype: file
     contains:
-    - "drupal-8.3.8-solr-7.x"
+    - "drupal-4.1.1-solr-7.x"
   /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml:
     exists: true
     filetype: file


### PR DESCRIPTION
- [GOVCMSD9-323] Pin GovCMS distribution 2.0.0 to lagoon release 9.1.2
- [GOVCMSD9-324] Update Dockerfile.solr in govcms/lagoon to fix the new change from search_api_solr module