### PR TITLE
Release/1.x/8.9.15

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -40,8 +40,8 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.16.0
-DRUPAL_CORE_VERSION=8.9.14
+GOVCMS_PROJECT_VERSION=1.17.0
+DRUPAL_CORE_VERSION=8.9.16
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases

--- a/.env.default
+++ b/.env.default
@@ -45,7 +45,7 @@ DRUPAL_CORE_VERSION=8.9.16
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.4.0
+LAGOON_IMAGE_VERSION=21.6.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
### Changes since 8.9.14:

- Update Lagoon base image from 21.4.0 to 21.6.0
- GovCMS distribution 1.17.0
- Update Drupal core from 8.9.14 to 8.9.16