### PR TITLE
GOVCMSD9-381 - Update the lagoon base images to 21.6.0 from 21.4.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=dev-2.x-develop
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.4.0
+LAGOON_IMAGE_VERSION=21.6.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
Update the lagoon base images to 21.6.0 from 21.4.0

v21.6.0

Changes in this release
use better terminology for default images @tobybellwood (#230)
Update alpine images to 3.13 @tobybellwood (#167)
add rabbitmq images to lagoon-images @tobybellwood (#198)
use github for mysqltuner @tobybellwood (#219)
version mariadb images @tobybellwood (#216)
Update php Docker tag to v8.0.7 (main) @renovate (#229)
Update php Docker tag to v7.4.20 (main) @renovate (#222)
Update composer Docker tag to v2.1.1 (main) @renovate (#228)
Update composer Docker tag to v2.1.0 (main) @renovate (#220)
Update Node.js to v16.3 (main) @renovate (#223)
Update postgres Docker tag to v12.7 (main) @renovate (#204)
Update postgres Docker tag to v11.12 (main) @renovate (#203)
Update ELK Stack Docker tags (main) (patch) @renovate (#179)
Update rabbitmq Docker tag to v3.8.16 (main) @renovate (#226)

21.5.0

Changes in this release
delete tests folder @tobybellwood (#214)
dual publish legacy image tags @tobybellwood (#199)
Fix PHP Yaml warning @seanhamlin (#213)
add Python 3.9 base images @tobybellwood (#168)
update renovate.json to remove maj/min PRs for redis/solr/varnish @tobybellwood (#195)
Update composer Docker tag to v2.0.14 (main) @renovate (#210)
Update python Docker tag to v3.9.5 (main) @renovate (#209)
Update python Docker tag to v3.8.10 (main) @renovate (#171)
Update Node.js to v16.2 (main) @renovate (#207)
Update node Docker tag to v16.1 (main) @renovate (#176)
Update Node.js to v14.17 (main) @renovate (#200)
Update php Docker tag to v8.0.6 (main) @renovate (#193)
Update php Docker tag to v7.4.19 (main) @renovate (#175)
Update php Docker tag to v7.4.18 (main) @renovate (#165)

