### PR TITLE
[GOVCMSD9-431] Update the lagoon base images to 21.7.0 from 21.6.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=dev-2.x-develop
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.6.0
+LAGOON_IMAGE_VERSION=21.7.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
https://github.com/uselagoon/lagoon-images/releases/tag/21.7.0