### PR TITLE
Release 9.1.6

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=dev-2.x-develop
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.6.0
+LAGOON_IMAGE_VERSION=21.7.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.

--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=dev-2.x-develop
+GOVCMS_PROJECT_VERSION=dev-release/2.x/2.3.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases


### PR DESCRIPTION
### Changes since 9.1.5:

1. Update the lagoon base images to 21.7.0 from 21.6.0
2. Pin GovCMS distribution 2.3.0 to lagoon release 9.1.6