### PR TITLE
[GOVCMSD9-506] Added govcms_security as a dependency.

### DIFF
--- a/modules/lagoon/govcms_lagoon/govcms_lagoon.info.yml
+++ b/modules/lagoon/govcms_lagoon/govcms_lagoon.info.yml
@@ -13,3 +13,4 @@ dependencies:
   - robotstxt:robotstxt
   - lagoon_logs:lagoon_logs
   - environment_indicator:environment_indicator
+  - govcms_security:govcms_security


### PR DESCRIPTION
Ensure `govcms_security` is enabled on deployment.