### PR TITLE
[GOVCMSD8-916] Update the base images

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -40,8 +40,8 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.20.0
-DRUPAL_CORE_VERSION=8.9.19
+GOVCMS_PROJECT_VERSION=1.19.0
+DRUPAL_CORE_VERSION=8.9.18
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases

--- a/.env.default
+++ b/.env.default
@@ -40,12 +40,12 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=1.19.0
-DRUPAL_CORE_VERSION=8.9.18
+GOVCMS_PROJECT_VERSION=1.20.0
+DRUPAL_CORE_VERSION=8.9.19
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=21.7.0
+LAGOON_IMAGE_VERSION=21.9.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
Update Lagoon base image from 21.7.0 to 21.9.0
https://github.com/uselagoon/lagoon-images/releases/tag/21.9.0

Deprecated Images
This release has removed NodeJS 10, Python 2.7, PHP 7.1, Solr 5.5, Solr 6.6 and their child images from the monthly updates. The last release 21.8.0 will always be the latest available for them.

Changes in this release
The major update to this release (other than deprecations) is the update of all possible base images to Alpine 3.14. The only remaining non-Alpine 3.14 images are all pinned to previous versions for compatibility (solr-7.7, varnish-5 and MongoDB), and the debian-based ones (solr-7 and varnish-6). In addition, we've automated the update of PECL-based packages (once again thanks to @renovate-bot!). We've also had to make minor modifications to the varnish-6 images to better accommodate variance between the debian packages and the varnish dev releases, but it should be more streamlined now.

Add in PECL packages to renovate.json @tobybellwood (#300)
update to alpine 3.14 @tobybellwood (#295)
update to varnish 6.6 @tobybellwood (#293)
add docker_pull command to Makefile to pull fresh upstream images @tobybellwood (#294)
Remove all EOL images @tobybellwood (#281)
Package Updates
Update dependency phpredis/phpredis to v5.3.4 (main) @renovate (#303)
Update dependency php/pecl-file_formats-yaml to v2.2.1 (main) @renovate (#302)
Update dependency krakjoe/apcu to v5.1.20 (main) @renovate (#301)
Update dependency xdebug/xdebug to v3.0.4 (main) @renovate (#304)
Update rabbitmq Docker tag to v3.8.22 (main) @renovate (#288)
Update redis Docker tag to v6.2.5 (main) @renovate (#296)
Update redis Docker tag to v6.2.4 (main) @renovate (#227)
Update alpine Docker tag to v3.13.6 (main) @renovate (#292)
Update alpine Docker tag to v3.12.8 (main) @renovate (#291)
Update composer Docker tag to v2.1.6 (main) @renovate (#283)
Update Node.js to v16.8 (main) @renovate (#284)
Update python Docker tag to v3.9.7 (main) @renovate (#290)
Update python Docker tag to v3.8.12 (main) @renovate (#289)
Update python Docker tag to v3.7.12 (main) @renovate (#299)
Update php Docker tag to v8.0.10 (main) @renovate (#287)
Update php Docker tag to v7.4.23 (main) @renovate (#286)
Update php Docker tag to v7.3.30 (main) @renovate (#285)