### PR TITLE
[GOVCMSD8-918]Update Drupal core from 8.9.18 to 8.9.19

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -41,7 +41,7 @@ SITE_AUDIT_VERSION=7.x-3.x
 # Note: the DRUPAL_CORE_VERSION here must match the version required in the corresponding GOVCMS_PROJECT_VERSION
 # See https://github.com/govCMS/govcms8/releases
 GOVCMS_PROJECT_VERSION=1.19.0
-DRUPAL_CORE_VERSION=8.9.18
+DRUPAL_CORE_VERSION=8.9.19
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases


### PR DESCRIPTION
https://www.drupal.org/project/drupal/releases/8.9.19
Release notes
Maintenance and security release of the Drupal 9 series.

This release fixes security vulnerabilities. Sites are urged to upgrade immediately after reading the notes below and the security announcement:

Drupal core - Moderately critical - Cross Site Request Forgery - SA-CORE-2021-006
Drupal core - Moderately critical - Cross Site Request Forgery - SA-CORE-2021-007
Drupal core - Moderately critical - Access Bypass - SA-CORE-2021-008
Drupal core - Moderately critical - Access Bypass - SA-CORE-2021-009
Drupal core - Moderately critical - Access Bypass - SA-CORE-2021-010
No other fixes are included.

Which release do I choose? Security coverage information
Sites on 8.9.x should update immediately to this release, but update to Drupal 9 as soon as possible afterward because Drupal 8 is end-of-life in six weeks! Starting in November 2021, Drupal 8 sites will no longer receive security updates. It is essential to update your Drupal 8 sites as soon as possible.
Versions of Drupal 8 prior to 8.9.x are end-of-life and do not receive security coverage.
Important update information
No changes have been made to the .htaccess, web.config, robots.txt, or default settings.php files in this release, so upgrading custom versions of those files is not necessary if your site is already on the previous release.