### PR TITLE
Require manual env var for latest tags.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,9 @@ workflow:
 .before_script_build: &before_script_build
   before_script:
     - if [ -z "$DEPLOY_TAG" ]; then echo "DEPLOY_TAG must be set for an actionable build."; exit 1; fi
+    # Latest tags need a confirmation var (provided manually: DEPLOY_LATEST)
+    - if [[ "$DEPLOY_TAG" == "8.x-latest"  ||  "$DEPLOY_TAG" == "9.x-latest" ]] && [ -z "$DEPLOY_LATEST" ]; then \
+        echo "DEPLOY_LATEST must be set to progress with 'latest' tags."; exit 1; fi
     - cp .env.default .env
     - sed -i -e "s/^GOVCMS_RELEASE_TAG.*/GOVCMS_RELEASE_TAG=$DEPLOY_TAG/" .env
     - cat .env


### PR DESCRIPTION
This additional check will require an `DEPLOY_LATEST` env var to be manually added on the pipeline run to build 8.x-latest and 9.x-latest tags.