### PR TITLE
Bump scaffold-tooling to 4.1.0 release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "cweagans/composer-patches": "^1.7",
         "govcms/govcms": "2.x-dev",
         "govcms/govcms-custom": "*",
-        "govcms/scaffold-tooling": "4.0.0",
+        "govcms/scaffold-tooling": "4.1.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {


### PR DESCRIPTION
https://github.com/govCMS/scaffold-tooling/releases/tag/4.1.0