### PR TITLE
[GOVCMS-7971] Adds support for securitytxt.

### DIFF
--- a/.docker/images/nginx/helpers/199-securitytxt.conf
+++ b/.docker/images/nginx/helpers/199-securitytxt.conf
@@ -1,0 +1,6 @@
+## Support for the securitytxt module
+## http://drupal.org/project/securitytxt.
+location = /.well-known/security.txt {
+    access_log off;
+    try_files $uri @drupal;
+}


### PR DESCRIPTION
Ensures Drupal bootstrap (or static file serve) for the `/.well-known/security.txt` route.

Upstream PR to Lagoon images here: https://github.com/uselagoon/lagoon-images/pull/500 - we can remove this helper once merged.