### PR TITLE
[GOVCMSD9-789] Update Search Api Solr to 4.2.8

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -2,7 +2,7 @@ ARG LAGOON_IMAGE_VERSION
 
 FROM uselagoon/php-8.1-cli-drupal:${LAGOON_IMAGE_VERSION} as builder
 
-COPY --from=ghcr.io/salsadigitalauorg/shipshape:0.1.12 /usr/local/bin/shipshape /usr/local/bin/shipshape
+COPY --from=ghcr.io/salsadigitalauorg/shipshape:0.1.13 /usr/local/bin/shipshape /usr/local/bin/shipshape
 
 ARG GOVCMS_PROJECT_VERSION
 ARG COMPOSER_AUTH

--- a/.docker/Dockerfile.solr
+++ b/.docker/Dockerfile.solr
@@ -9,14 +9,18 @@ RUN sed -i -e "s#<dataDir>\${solr.data.dir:}#<dataDir>/var/solr/\${solr.core.nam
     && sed -i -e "s#solr.lock.type:native#solr.lock.type:none#g" /solr-conf/conf/solrconfig.xml \
     && sed -i -e "s#solr.install.dir=../../..#solr.install.dir=/opt/solr#g" /solr-conf/conf/solrcore.properties
 
-RUN sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#4.2.7#g" /solr-conf/conf/schema.xml \
+RUN sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#4.2.8#g" /solr-conf/conf/schema.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_SCHEMA_VERSION#4.2.8#g" /solr-conf/conf/schema.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_BRANCH#7.x#g" /solr-conf/conf/schema.xml \
     && sed -i -e "s#SEARCH_API_SOLR_JUMP_START_CONFIG_SET#1#g" /solr-conf/conf/schema.xml \
-    && sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#4.2.7#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_MIN_SCHEMA_VERSION#4.2.8#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_SCHEMA_VERSION#4.2.8#g" /solr-conf/conf/solrconfig.xml \
+    && sed -i -e "s#SEARCH_API_SOLR_BRANCH#7.x#g" /solr-conf/conf/solrconfig.xml \
     && sed -i -e "s#SEARCH_API_SOLR_JUMP_START_CONFIG_SET#1#g" /solr-conf/conf/solrconfig.xml \
-    && sed -i -e "s#drupal-8.3.8-solr-7.x#drupal-4.2.7-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/schema.xml \
-    && sed -i -e "s#drupal-8.3.8-solr-7.x#drupal-4.2.7-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml \
-    && sed -i -e "s#drupal-4.2.1-solr-7.x-1#drupal-4.2.7-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/schema.xml \
-    && sed -i -e "s#drupal-4.2.1-solr-7.x-1#drupal-4.2.7-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml
+    && sed -i -e "s#drupal-8.3.8-solr-7.x#drupal-4.2.8-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/schema.xml \
+    && sed -i -e "s#drupal-8.3.8-solr-7.x#drupal-4.2.8-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml \
+    && sed -i -e "s#drupal-4.2.1-solr-7.x-1#drupal-4.2.8-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/schema.xml \
+    && sed -i -e "s#drupal-4.2.1-solr-7.x-1#drupal-4.2.8-solr-7.x-1#g" /opt/solr/server/solr/mycores/drupal/conf/solrconfig.xml
 
 USER solr
 RUN precreate-core drupal /solr-conf/conf


### PR DESCRIPTION
Changes:

1. Update Search API Solr to 4.2.8
2. Add new constant SEARCH_API_SOLR_SCHEMA_VERSION and SEARCH_API_SOLR_BRANCH to be compatible with new configurations.