### PR TITLE
[GOVCMSD9-969] Update lagoon base images to 22.11.0 from 22.10.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=2.24.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=22.10.0
+LAGOON_IMAGE_VERSION=22.11.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
https://github.com/uselagoon/lagoon-images/releases/tag/22.11.0