### PR TITLE
Stick to Drush 10.x in govcms/lagoon images.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "govcms/govcms": "2.x-dev",
         "govcms/govcms-custom": "*",
         "govcms/scaffold-tooling": "4.4.0",
-        "webmozart/path-util": "^2.3"
+        "webmozart/path-util": "^2.3",
+        "drush/drush": "^10"
     },
     "require-dev": {
         "drupal/core-dev": "^9.0"


### PR DESCRIPTION
This allows the ~11 constraint in the scaffold-tooling (PaaS customers) while keeping SaaS on Drush 10.x for now.