### PR TITLE
9.5.2 release

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ SITE_AUDIT_VERSION=7.x-3.x
 
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (1.x-dev) here
 # See https://github.com/govCMS/govcms8/releases
-GOVCMS_PROJECT_VERSION=2.30.0
+GOVCMS_PROJECT_VERSION=2.31.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases

--- a/.env.default
+++ b/.env.default
@@ -43,7 +43,7 @@ GOVCMS_PROJECT_VERSION=2.31.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=23.4.0
+LAGOON_IMAGE_VERSION=23.5.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "cweagans/composer-patches": "^1.7",
         "govcms/govcms": "2.x-dev",
         "govcms/govcms-custom": "*",
-        "govcms/scaffold-tooling": "4.5.0",
+        "govcms/scaffold-tooling": "4.6.0",
         "webmozart/path-util": "^2.3",
         "drush/drush": "^10"
     },


### PR DESCRIPTION
No distribution change, just updates to the latest versions of Lagoon base images and scaffold-tooling.