### PR TITLE
Fix: Set session.cookie_samesite.

### DIFF
--- a/.docker/images/php/01-govcms.ini
+++ b/.docker/images/php/01-govcms.ini
@@ -2,5 +2,6 @@
 
 session.gc_maxlifetime=3600
 session.cookie_lifetime=0
+session.cookie_samesite=Lax
 upload_max_filesize=256M
 post_max_size=256M


### PR DESCRIPTION
New Chrome settings force cookie handling, Drupal 9.3+ added `session.cookie_samesite` 