### PR TITLE
GOVCMSD10-390] Update lagoon base images from 23.11.0 to 23.12.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=3.6.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=23.11.0
+LAGOON_IMAGE_VERSION=23.12.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
Release:

https://github.com/uselagoon/lagoon-images/releases/tag/23.12.0

Notes on this release

New Images

PHP8.3 is released. Note that there is no support for NewRelic or Blackfire yet. Additionally, the version of NodeJS included in this release is v20, from v18 in the 8.1 & 8.2 images)

Changes in this release

fix for php8.3 imagick 3.7.0 build on arm64 [@tobybellwood](https://github.com/tobybellwood) ([#893](https://github.com/uselagoon/lagoon-images/pull/893))
Add PHP8.3 images [@tobybellwood](https://github.com/tobybellwood) ([#877](https://github.com/uselagoon/lagoon-images/pull/877))
Dockerfile package tidy and add rsync & tar to all images [@tobybellwood](https://github.com/tobybellwood) ([#891](https://github.com/uselagoon/lagoon-images/pull/891))
Improve comments and fix examples in redirects-map.conf [@rocketeerbkw](https://github.com/rocketeerbkw) ([#882](https://github.com/uselagoon/lagoon-images/pull/882))
Package Updates

Update alpine Docker tag to v3.18.5 (main) [@renovate](https://github.com/renovate) ([#885](https://github.com/uselagoon/lagoon-images/pull/885))
Update alpine Docker tag to v3.17.6 (main) [@renovate](https://github.com/renovate) ([#884](https://github.com/uselagoon/lagoon-images/pull/884)
Update php Docker tag to v8.2.13 (main) [@renovate](https://github.com/renovate) ([#880](https://github.com/uselagoon/lagoon-images/pull/880))
Update php Docker tag to v8.1.26 (main) [@renovate](https://github.com/renovate) ([#879](https://github.com/uselagoon/lagoon-images/pull/879))
Update dependency composer/composer to v2.6.6 (main) [@renovate](https://github.com/renovate) ([#892](https://github.com/uselagoon/lagoon-images/pull/892) and [#889](https://github.com/uselagoon/lagoon-images/pull/889))
Update Node.js to v20.10 (main) [@renovate](https://github.com/renovate) ([#881](https://github.com/uselagoon/lagoon-images/pull/881))
Update Node.js to v18.19.0 (main) [@renovate](https://github.com/renovate) ([#887](https://github.com/uselagoon/lagoon-images/pull/887))
Update openresty/openresty Docker tag to v1.21.4.3-2-alpine (main) [@renovate](https://github.com/renovate) ([#878](https://github.com/uselagoon/lagoon-images/pull/878))
Update opensearchproject/opensearch Docker tag to v2.11.1 (main) [@renovate](https://github.com/renovate) ([#886](https://github.com/uselagoon/lagoon-images/pull/886))
Update python Docker tag to v3.12.1 (main) [@renovate](https://github.com/renovate) ([#890](https://github.com/uselagoon/lagoon-images/pull/890))
Update python Docker tag to v3.11.7 (main) [@renovate](https://github.com/renovate) ([#888](https://github.com/uselagoon/lagoon-images/pull/888))