### PR TITLE
Fix: Add aliases for drush and composer.

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -30,6 +30,7 @@ ENV COMPOSER_MEMORY_LIMIT=-1
 RUN [[ ! -z "${GITHUB_TOKEN}" ]]  && composer config -g github-oauth.github.com ${GITHUB_TOKEN} || echo "Personal Github OAuth token is not set."
 
 RUN composer validate \
+   && composer self-update --2 \
    && composer update -d /app \
    && composer clearcache
 

--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -28,13 +28,13 @@ COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 ENV COMPOSER_MEMORY_LIMIT=-1
 # Set the Github OAuth token only when the variable is set.
 RUN [[ ! -z "${GITHUB_TOKEN}" ]]  && composer config -g github-oauth.github.com ${GITHUB_TOKEN} || echo "Personal Github OAuth token is not set."
+
 RUN composer validate \
-   && composer self-update --2 \
    && composer update -d /app \
    && composer clearcache
 
-# Override global Drush8 with Drush12.
-ENV PATH="/app/vendor/bin:${PATH}"
+# Add bash aliases to assist with full path executables.
+COPY .docker/images/govcms/entrypoints /lagoon/entrypoints/
 
 COPY .docker/sanitize.sh /app/sanitize.sh
 

--- a/.docker/images/govcms/entrypoints/55-cli-helpers.sh
+++ b/.docker/images/govcms/entrypoints/55-cli-helpers.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Provide aliases to help with general operations.
+# The default uselagoon bashrc skips the standard .bash_aliases include
+# so we override this file and include our aliases here.
+#
+# @see https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/entrypoints/55-cli-helpers.sh
+
+dsql () {
+	drush sql-sync $1 @self
+}
+
+dfiles () {
+	drush rsync $1:%files @self:%files
+}
+
+# end Lagoon helpers.
+
+# Ensure absolute paths are used.
+alias composer=/usr/local/bin/composer
+alias drush=/app/vendor/bin/drush


### PR DESCRIPTION
Drush 12 requires overriding the location of the drush executable as this is no longer compatible with Drush launcher and the base images install drush launcher. Previously this was done by appending `/app/vendor/bin` to the `$PATH` which would mean that `drush` would load from `/app/vendor/bin` instead or `/usr/local/bin`. 

This had the unexpected side effect that changed the load location of `composer`. Composer is included as a local dependency and provides a new composer executable in `/app/vendor/bin/composer`. This overrode the default location for composer and caused composer to load from the local install. This version of composer is slightly different in how it resolves and updates dependencies which results in SaaS+ not being able to run composer updates due to sanitise.sh removing files that it expects to exist.