### PR TITLE
Hotfix: Composer path.

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -33,8 +33,8 @@ RUN composer validate \
    && composer update -d /app \
    && composer clearcache
 
-# Override global Drush8 with Drush12.
-ENV PATH="/app/vendor/bin:${PATH}"
+# Add bash aliases to assist with full path executables.
+COPY .docker/images/govcms/entrypoints /lagoon/entrypoints/
 
 COPY .docker/sanitize.sh /app/sanitize.sh
 

--- a/.docker/images/govcms/entrypoints/55-cli-helpers.sh
+++ b/.docker/images/govcms/entrypoints/55-cli-helpers.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Provide aliases to help with general operations.
+# The default uselagoon bashrc skips the standard .bash_aliases include
+# so we override this file and include our aliases here.
+#
+# @see https://github.com/uselagoon/lagoon-images/blob/main/images/php-cli/entrypoints/55-cli-helpers.sh
+
+dsql () {
+	drush sql-sync $1 @self
+}
+
+dfiles () {
+	drush rsync $1:%files @self:%files
+}
+
+# end Lagoon helpers.
+
+# Ensure absolute paths are used.
+alias composer=/usr/local/bin/composer
+alias drush=/app/vendor/bin/drush


### PR DESCRIPTION
- Add aliases for `composer` and `drush` to ensure correct binary usage