### PR TITLE
[GOVCMSD10-399] Remove module_filter module from lagoon codebase

### DIFF
--- a/modules/distro/d8-stubs/module_filter/module_filter.info.yml
+++ b/modules/distro/d8-stubs/module_filter/module_filter.info.yml
@@ -1,3 +1,0 @@
-name: module_filter
-type: module
-core_version_requirement: ^9 || ^10


### PR DESCRIPTION
Deprecate [Module Filter](https://www.drupal.org/project/module_filter) module from GovCMS.

**Step 1: Uninstall the module in this release if it's lifecycle is obsolete** 

Step 2: Remove https://github.com/govCMS/GovCMS/tree/3.x-develop/modules/obsolete/module_filter stub module from the distribution codebase in the next release.