### PR TITLE
[GOVCMSD10-440] Update lagoon base images from 23.12.0 to 24.1.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=3.7.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=23.12.0
+LAGOON_IMAGE_VERSION=24.1.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
**Release:**

https://github.com/uselagoon/lagoon-images/releases/tag/24.1.0

**Notes on this release**

This release updates *most images to Alpine 3.19. For some older images (eg MariaDB10.4) there are no Alpine3.19 equivalents, so they remain on their existing version. Additionally, in testing, we discovered a couple of issues with the 3.19 releases of PHP8.1 and PHP8.3, so have kept those images at 3.18 whilst we investigate.

With the update to Alpine3.19, the version of NodeJS included in all PHP images has been updated to version 20 (it was previously 18 in PHP 8.1 and 8.2)

This release also brings PHP8.3 support for New Relic and Blackfire integrations.

**Deprecated Images**
The PHP 8.0 images are no longer being published or updated. The latest tag will permanently point to the 23.12.0 release.

**Changes in this release**
Improve MariaDB performance monitoring settings @rocketeerbkw (#913)
revert php 8.1 and 8.3 to alpine 3.18 @tobybellwood (#916)
Upgrade alpine to 3.19 @bomoko (#911)
Deprecate PHP 8.0 @bomoko (#908)
Install New Relic and Blackfire agents in PHP 8.3 images @rocketeerbkw (#907)
Package Updates
Update php Docker tag to v8.3.2 (main) @renovate (#900)
Update php Docker tag to v8.2.15 (main) @renovate (#899)
Update php Docker tag to v8.1.27 (main) @renovate (#898)
chore(deps): update dependency newrelic/newrelic-php-agent to v10.16.0.5 (main) @renovate (#917)
Update dependency newrelic/newrelic-php-agent to v10.15.0.4 (main) @renovate (#897)
Update dependency blackfire/docker to v2.24.4 (main) @renovate (#896)
Update dependency xdebug/xdebug to v3.3.1 (main) @renovate (#883)
chore(deps): update redis docker tag to v7.2.4 (main) @renovate (#915)
Update Node.js to v20.11.0 (main) @renovate (#904)
Update ruby Docker tag to v3.2.3 (main) @renovate (#912)
Update openresty/openresty Docker tag to v1.21.4.3-3-alpine (main) @renovate (#902)