### PR TITLE
[GOVCMSD10-537] Remove egulias/email-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "drupal/bartik": "^1.0",
-        "egulias/email-validator": "4.0.1 as 3.2.6",
         "govcms/govcms": "3.x-develop-dev",
         "govcms/govcms-custom": "*",
         "govcms/scaffold-tooling": "5.2.1",


### PR DESCRIPTION
No longer required after removal of swiftmailer