### PR TITLE
[GOVCMSD10-623] Mark CKEditor 4 as obsolete in lagoon

### DIFF
--- a/modules/distro/ckeditor/ckeditor.info.yml
+++ b/modules/distro/ckeditor/ckeditor.info.yml
@@ -1,7 +1,7 @@
 name: CKEditor 4 (contrib)
 type: module
 description: "WYSIWYG editing for rich text fields using CKEditor."
-lifecycle: deprecated
+lifecycle: obsolete
 lifecycle_link: https://www.drupal.org/node/3223395#s-ckeditor
 core_version_requirement: "^9.4 || ^10"
 dependencies:


### PR DESCRIPTION
Uninstall CKEditor 4 from lagoon - https://github.com/govCMS/lagoon/tree/3.x-develop/modules/distro/ckeditor 

In distribution:

1. We're marking ckeditor as obsolete in the GovCMS lifecycle.
3. We're marking ckeditor as obsolete in lagoon https://github.com/govCMS/lagoon/blob/3.x-develop/modules/distro/ckeditor/ckeditor.info.yml#L4.
5. After deployment, Salsa will run a post script to uninstall the ckeditor module.
7. We don't need to provide an update hook.