### PR TITLE
[GOVCMSD10-711] Update lagoon base images from 24.1.0 to 24.3.1

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=3.10.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=24.1.0
+LAGOON_IMAGE_VERSION=24.3.1
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
**Release:**

[Release lagoon-images 24.3.1 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/24.3.1) 

**Notes on this release**
What-ho, a dot release. Just a mini-one, mainly to bring forth some MariaDB crash recovery options needed in Lagoon, but also Python and Varnish updates, just because...

**Changes in this release**
Improve MariaDB crash recovery options and reduce warnings [@rocketeerbkw](https://github.com/rocketeerbkw) ([#957](https://github.com/uselagoon/lagoon-images/pull/957))

**Package Updates**
chore(deps): update varnish docker tag to v7.5 (main) [@renovate](https://github.com/renovate) ([#956](https://github.com/uselagoon/lagoon-images/pull/956))

chore(deps): update varnish docker tag to v6.0.13 (main) [@renovate](https://github.com/renovate) ([#955](https://github.com/uselagoon/lagoon-images/pull/955))

chore(deps): update python docker tag to v3.10.14 (main) [@renovate](https://github.com/renovate) ([#958](https://github.com/uselagoon/lagoon-images/pull/958))

chore(deps): update python docker tag to v3.9.19 (main) - autoclosed [@renovate](https://github.com/renovate) ([#960](https://github.com/uselagoon/lagoon-images/pull/960))

chore(deps): update python docker tag to v3.8.19 (main) [@renovate](https://github.com/renovate) ([#959](https://github.com/uselagoon/lagoon-images/pull/959))