### PR TITLE
Build with latest distro release branch when USE_LATEST_RELEASE_BRANCH is set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,28 +27,6 @@ workflow:
       variables:
         DEPLOY_TAG: "10.x-beta"
 
-    ## D9
-    - if: $CI_COMMIT_REF_NAME == "2.x-develop"
-      variables:
-        DEPLOY_TAG: "9.x-edge"
-    - if: $CI_COMMIT_REF_NAME == "2.x-master"
-      variables:
-        DEPLOY_TAG: "9.x-latest"
-    - if: $CI_COMMIT_REF_NAME =~ /^release\/2.x\//
-      variables:
-        DEPLOY_TAG: "9.x-beta"
-    - if: $CI_COMMIT_REF_NAME == "feature/2.x/php8"
-      variables:
-        DEPLOY_TAG: "9.x-php8"
-
-    ## D8
-    - if: $CI_COMMIT_REF_NAME == "1.x-develop"
-      variables:
-        DEPLOY_TAG: "8.x-edge"
-    - if: $CI_COMMIT_REF_NAME == "1.x-master"
-      variables:
-        DEPLOY_TAG: "8.x-latest"
-
     ## Release tags.
     - if: $CI_COMMIT_TAG != null
       variables:
@@ -75,9 +53,17 @@ workflow:
   before_script:
     - if [ -z "$DEPLOY_TAG" ]; then echo "DEPLOY_TAG must be set for an actionable build."; exit 1; fi
     # Latest tags need a confirmation var (provided manually: DEPLOY_LATEST)
-    - if [[ "$DEPLOY_TAG" == "8.x-latest"  ||  "$DEPLOY_TAG" == "9.x-latest" || "$DEPLOY_TAG" == "10.x-latest" ]] && [ -z "$DEPLOY_LATEST" ]; then echo "DEPLOY_LATEST must be set to progress with 'latest' tags."; exit 1; fi
+    - if [[ "$DEPLOY_TAG" == "10.x-latest" ]] && [ -z "$DEPLOY_LATEST" ]; then echo "DEPLOY_LATEST must be set to progress with 'latest' tags."; exit 1; fi
     - cp .env.default .env
     - sed -i -e "s/^GOVCMS_RELEASE_TAG.*/GOVCMS_RELEASE_TAG=$DEPLOY_TAG/" .env
+    # Determine and use latest distribution release branch if USE_LATEST_RELEASE_BRANCH is set
+    - |
+      if [ -z "$USE_LATEST_RELEASE_BRANCH"]; then
+        echo "Determining latest release branch in use at govcms/govcms"
+        cd /tmp && git clone https://github.com/govCMS/GovCMS.git && cd GovCMS
+        LATEST=`git for-each-ref --sort=-committerdate refs/remotes/ --format='%(refname)' | sed 's/refs\/remotes\/origin\///g' | grep release/3.x/ | head -1`
+        sed -i -e "s/^GOVCMS_PROJECT_VERSION.*/GOVCMS_PROJECT_VERSION=dev-$LATEST/" .env
+      fi
     - cat .env
     - update-binfmts --enable # Important: Ensures execution of other binary formats is enabled in the kernel
     - export $(grep -v '^#' .env | xargs)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,9 +60,11 @@ workflow:
     - |
       if [ -z "$USE_LATEST_RELEASE_BRANCH"]; then
         echo "Determining latest release branch in use at govcms/govcms"
+        WORKING_DIR=`pwd`
         cd /tmp && git clone https://github.com/govCMS/GovCMS.git && cd GovCMS
         LATEST=`git for-each-ref --sort=-committerdate refs/remotes/ --format='%(refname)' | sed 's/refs\/remotes\/origin\///g' | grep release/3.x/ | head -1`
-        sed -i -e "s/^GOVCMS_PROJECT_VERSION.*/GOVCMS_PROJECT_VERSION=dev-$LATEST/" .env
+        cd $WORKING_DIR
+        sed -i -e "s#^GOVCMS_PROJECT_VERSION.*#GOVCMS_PROJECT_VERSION=dev-$LATEST#" .env
       fi
     - cat .env
     - update-binfmts --enable # Important: Ensures execution of other binary formats is enabled in the kernel


### PR DESCRIPTION
- Removes legacy D8/D9 build variables
- When `USE_LATEST_RELEASE_BRANCH` is set in CI the latest release branch (e.g `release/3.x/*`) from the distribution git repo will be used for the build