### PR TITLE
[GOVCMSD10-616] Check modules/custom's existance before linting

### DIFF
--- a/.docker/scripts/lint-govcms
+++ b/.docker/scripts/lint-govcms
@@ -4,14 +4,24 @@
 APP_DIR=${APP_DIR:-/app}
 PROFILE_DIR=${PROFILE_DIR:-${APP_DIR}/web/profiles/govcms}
 
+# Array of files and directories to be linted.
+DIR_ARRAY=(
+    "${PROFILE_DIR}/themes/govcms"
+    "${PROFILE_DIR}/govcms.info"
+    "${PROFILE_DIR}/govcms.install"
+    "${PROFILE_DIR}/govcms.profile"
+    "${APP_DIR}/tests"
+)
+# Ensure the module/custom directory exists, otherwise ignore from linting.
+if [ -d "${PROFILE_DIR}/modules/custom" ]; then
+    DIR_ARRAY+=("${PROFILE_DIR}/modules/custom")
+fi
+
 # Lint code.
-${APP_DIR}/tests/vendor/bin/parallel-lint --exclude ${APP_DIR}/tests/vendor -e php,inc,module,theme,install,profile,test \
-        ${PROFILE_DIR}/modules/custom \
-        ${PROFILE_DIR}/themes/govcms \
-        ${PROFILE_DIR}/govcms.info \
-        ${PROFILE_DIR}/govcms.install \
-        ${PROFILE_DIR}/govcms.profile \
-        ${APP_DIR}/tests
+${APP_DIR}/tests/vendor/bin/parallel-lint \
+    --exclude ${APP_DIR}/tests/vendor \
+    -e php,inc,module,theme,install,profile,test \
+    "${DIR_ARRAY[@]}"
 
 # Validate makefile.
 cd ${PROFILE_DIR} && drush verify-makefile


### PR DESCRIPTION
Prevent php-parallel-lint from being told to run over the modules/custom directory when it in fact does not exist.

This directory is not present in a default installation, and without this check, `ahoy lint` fails on SaaS sites without this directory. 