### PR TITLE
[DEVOPS-516] Add `--no-dev` to composer update

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -25,7 +25,7 @@ COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 ENV COMPOSER_MEMORY_LIMIT=-1
 
 RUN --mount=type=secret,id=composer-auth,dst=/app/auth.json /usr/local/bin/composer validate
-RUN --mount=type=secret,id=composer-auth,dst=/app/auth.json /usr/local/bin/composer update -d /app
+RUN --mount=type=secret,id=composer-auth,dst=/app/auth.json /usr/local/bin/composer update --no-dev -d /app
 RUN --mount=type=secret,id=composer-auth,dst=/app/auth.json /usr/local/bin/composer clearcache
 
 # Add bash aliases to assist with full path executables.

--- a/.docker/sanitize.sh
+++ b/.docker/sanitize.sh
@@ -47,3 +47,6 @@ find $APP_DIR/web/libraries/ -type d -name samples -exec rm -rf {} +
 find $APP_DIR/web/sites -type d -exec chmod 755 {} +
 find $APP_DIR/web/sites -type f -exec chmod 644 {} +
 chmod 755 $APP_DIR/web/sites
+
+# Remove unnecessary vendor files.
+rm -f $APP_DIR/vendor/symfony/console/Resources/bin/hiddeninput.exe


### PR DESCRIPTION
- That prevents the image from always installing rector.
- Also removed hiddeninput.exe since not used in the cloud.