### PR TITLE
feat: adds a secrets entrypoint

### DIFF
--- a/.docker/images/govcms/entrypoints/56-secrets.sh
+++ b/.docker/images/govcms/entrypoints/56-secrets.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Copy the composer auth.json file to the user's home
+# directory if present in secrets.
+if [ -f /run/secrets/composer-github-auth ]; then
+  cp /run/secrets/composer-github-auth /home/.composer/auth.json
+fi


### PR DESCRIPTION
Allows specifying a composer auth.json as a secret in docker-compose.yml, which would then be used when running composer commands.

Example usage:
```yml
# docker-compose.override.yml
services:
  cli:
    secrets:
      - composer-github-auth

secrets:
  composer-github-auth:
    file: $HOME/.composer/auth.json
```