### PR TITLE
fix: add `laminas/laminas-feed` package to support aggregator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 auth.json
+docker-compose.override.yml

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "govcms/govcms": "3.x-develop-dev",
         "govcms/govcms-custom": "*",
         "govcms/scaffold-tooling": "5.3.0",
+        "laminas/laminas-feed": "^2.17",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,0 +1,8 @@
+services:
+  cli:
+    secrets:
+      - composer-auth
+
+secrets:
+  composer-auth:
+    file: $HOME/.composer/auth.json


### PR DESCRIPTION
A couple projects use the `aggregator` module from this repository, but the image is missing the `laminas/laminas-feed` composer package, thereby failing the commands that use the module. Adding this package should fix this issue.