### PR TITLE
Release 10.2.4 (#419)

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -35,7 +35,7 @@ X_FRAME_OPTIONS=SAMEORIGIN
 
 # Set the version of GovCMS and Drupal Core to use - you can use a tag or branch reference (3.x-dev) here
 # See https://github.com/govCMS/GovCMS/releases
-GOVCMS_PROJECT_VERSION=3.15.0
+GOVCMS_PROJECT_VERSION=3.16.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases


### PR DESCRIPTION
* [DEVOPS-516] Add --no-dev to composer update

- That prevents the image from always installing rector.
- Also removed hiddeninput.exe since not used in the cloud.

* feat: adds a secrets entrypoint

Allows specifying a composer auth.json as a secret in docker-compose.yml, which would then be used when running composer commands

* Update Lagoon release version from 24.6.0 to 24.7.0 (#415)

* fix GOVCMS_PROJECT_VERSION

* Increased per_page value for API response.

* Fixed per_page value for multiarch build stage.

* Use latest scaffold-tooling release.

* Pin GovCMS 3.16.0

---------