### PR TITLE
[GOVCMSD10-1106] Update the base images to the latest Lagoon images from 24.8.0 to 24.9.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=3.18.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=24.8.0
+LAGOON_IMAGE_VERSION=24.9.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
https://github.com/uselagoon/lagoon-images/releases/tag/24.9.0 