### PR TITLE
[GOVCMSD10-1163] Fix local mysql import error

### DIFF
--- a/.docker/config/simplesaml/config/config.php
+++ b/.docker/config/simplesaml/config/config.php
@@ -495,7 +495,7 @@ $config = [
     /*
      * (Optional) Driver options
      */
-    'database.driver_options' => [],
+    'database.driver_options' => [\PDO::MYSQL_ATTR_INIT_COMMAND => "SET collation_connection = utf8mb4_general_ci"],
 
     /*
      * True or false if you would like a persistent database connection


### PR DESCRIPTION
The Simplesamlphp and drupal database tables use different collations.

Simplesaml uses `utf8mb4_0900_ai_ci` but drupal uses `utf8mb4_general_ci`.

This causes errors in local test sites when attempting to import lagoon database backups to a local site. In particular, the following error is received:
```
ahoy mysql-import ~/Downloads/vanilla-govcms-10-beta-test-mariadb-prebackuppod.mariadb.sql

Do you really want to drop all tables in the database drupal? (yes/no) [yes]:
> yes

> ERROR 1273 (HY000) at line 25: Unknown collation: 'utf8mb4_0900_ai_ci'

In Process.php line 270:

  The command "mysql --defaults-file=/tmp/drush_ONjodh --database=drupal --ho  
  st=mariadb --port=3306 -A" failed.                                           

  Exit Code: 1(General error)                                                  

  Working directory: /app/web                                                  

  Output:                                                                      
  ================                                                             

  Error Output:                                                                
  ================                                                             
  ERROR 1273 (HY000) at line 25: Unknown collation: 'utf8mb4_0900_ai_ci'
```

The change I propose to fix this is to explicitly tell simplesamlphp to use the `utf8mb4_general_ci` collation.