### PR TITLE
[DEVOPS-467] Removed abandoned package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "drupal/bartik": "^1.0",
         "govcms/govcms": "3.x-develop-dev",
         "govcms/govcms-custom": "*",
-        "govcms/scaffold-tooling": "5.4.0",
-        "webmozart/path-util": "^2.3"
+        "govcms/scaffold-tooling": "5.4.0"
     },
     "require-dev": {
         "drupal/core-dev": "^10.0",


### PR DESCRIPTION
# Issue
On composer install we see the following warning. 

```Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.```

# Proposed solution
To ensure that we’re running up-to-date software we need to remove abandoned packages.