### PR TITLE
Admin paths not loading correctly

### DIFF
--- a/.docker/images/nginx/helpers/206-x_robots_tag_header.conf
+++ b/.docker/images/nginx/helpers/206-x_robots_tag_header.conf
@@ -12,7 +12,7 @@ if ($host ~* ^(?!www\.govcms\.gov\.au$)(?:[\w\-]+\.)+govcms\.gov\.au$){
 }
 
 # Set none for Drupal /admin and /user routes.
-location ~* ^/(admin|user)/.*$ {
+if ($uri ~* ^/(admin|user)/.*$) {
   set $robots_header "none";
 }
 


### PR DESCRIPTION
Recent commit used a location block tp set 'none' for the `X-Robots-Tag` header. This caused the request to not be handed off to Drupal correctly, causing the pages to come back as 404's and to not be able to process form submission correctly. This changes the way the check for admin or user path is done.