### PR TITLE
[SimpleSAMLPhp] - Added ability to use distinct Logout bindings.

### DIFF
--- a/.docker/config/simplesaml/config/authsources.php
+++ b/.docker/config/simplesaml/config/authsources.php
@@ -83,7 +83,7 @@ $config = [
          * Whether authentication requests, logout requests and logout responses received from this SP should be validated.
          * The default is FALSE 
          */
-        'redirect.validate' => filter_var(getenv('SIMPLESAMLPHP_SP_VALIDATE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true
+        'redirect.validate' => filter_var(getenv('SIMPLESAMLPHP_SP_VALIDATE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
 
         /*
          * Whether we require signatures on authentication requests sent from this SP. Set it to:

--- a/.docker/config/simplesaml/metadata/saml20-idp-remote.php
+++ b/.docker/config/simplesaml/metadata/saml20-idp-remote.php
@@ -5,19 +5,30 @@ $idpEntityId = getenv('SIMPLESAMLPHP_IDP_ENTITYID') ?: $idpBaseURL;
 $fallbackBinding = getenv('SIMPLESAMLPHP_IDP_DEFAULT_BINDING');
 
 $bindings = [
-  'SIMPLESAMLPHP_IDP_HTTP_POST_BINDING' => $fallbackBinding,
-  'SIMPLESAMLPHP_IDP_HTTP_REDIRECT_BINDING' => $fallbackBinding,
-  'SIMPLESAMLPHP_IDP_SOAP_BINDING' => $fallbackBinding,
-  'SIMPLESAMLPHP_IDP_HTTP_ARTIFACT' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_HTTP_POST_BINDING' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_HTTP_REDIRECT_BINDING' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_SOAP_BINDING' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_HTTP_ARTIFACT' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_LOGOUT_HTTP_POST_BINDING' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_LOGOUT_HTTP_REDIRECT_BINDING' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_LOGOUT_SOAP_BINDING' => $fallbackBinding,
+    'SIMPLESAMLPHP_IDP_LOGOUT_HTTP_ARTIFACT' => $fallbackBinding
 ];
 
+// Override fallback binding if env variable value is present.
 foreach ($bindings as $binding => $fallback) {
-  $envVar = getenv($binding);
-  if (empty($envVar)) {
-    $bindings[$binding] = str_starts_with($fallback, 'http') ? $fallback : $idpBaseURL . $fallback;
-    continue;
-  }
-  $bindings[$binding] = str_starts_with($envVar, 'http') ? $envVar : $idpBaseURL . $envVar;
+    $envVar = getenv($binding);
+
+    // Apply special logic for logout bindings.
+    if (strpos($binding, 'LOGOUT') !== false) {
+        if (empty($envVar)) {
+            // Try fallback to the corresponding non-logout binding first.
+            $envVar = getenv(str_replace('LOGOUT', '', $binding)) ?: $fallback;
+        }
+    }
+
+    // Fallback to the base URL if needed.
+    $bindings[$binding] = str_starts_with($envVar, 'http') ? $envVar : $idpBaseURL . $envVar;
 }
 
 $metadata[$idpEntityId] = [
@@ -46,19 +57,19 @@ $metadata[$idpEntityId] = [
   'SingleLogoutService' => [
     [
       'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-      'Location' => $bindings['SIMPLESAMLPHP_IDP_HTTP_POST_BINDING'],
+      'Location' => $bindings['SIMPLESAMLPHP_IDP_LOGOUT_HTTP_POST_BINDING'],
     ],
     [
       'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
-      'Location' => $bindings['SIMPLESAMLPHP_IDP_HTTP_REDIRECT_BINDING'],
+      'Location' => $bindings['SIMPLESAMLPHP_IDP_LOGOUT_HTTP_REDIRECT_BINDING'],
     ],
     [
       'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact',
-      'Location' => $bindings['SIMPLESAMLPHP_IDP_HTTP_ARTIFACT'],
+      'Location' => $bindings['SIMPLESAMLPHP_IDP_LOGOUT_HTTP_ARTIFACT'],
     ],
     [
       'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:SOAP',
-      'Location' => $bindings['SIMPLESAMLPHP_IDP_SOAP_BINDING'],
+      'Location' => $bindings['SIMPLESAMLPHP_IDP_LOGOUT_SOAP_BINDING'],
     ],
   ],
   'ArtifactResolutionService' => [


### PR DESCRIPTION
# Issue
Currently, `SingleSignOnService` and `SingleLogoutService` metadata bindings use the same values for each respective binding. This introduces a limitation to a use-case when those bindings won't be the same.

# Proposed solution
Add ability to provide distinct `SingleLogoutService` bindings, only then to fallback to `SingleSignOnService` bindings.