### PR TITLE
Reduce SBOM log noise

### DIFF
--- a/.docker/images/nginx/helpers/100_x-robots-header-development.conf
+++ b/.docker/images/nginx/helpers/100_x-robots-header-development.conf
@@ -55,7 +55,7 @@ header_filter_by_lua_block {
             },
         })
         if not res then
-            ngx.log(ngx.ERR, "request failed: ", err)
+            ngx.log(ngx.ERR, "Request to JS SBOM API failed: ", err)
             return
         end
     end
@@ -63,7 +63,7 @@ header_filter_by_lua_block {
     if os.getenv("JS_SBOM_FILE_LOCATION") then
         local f, err = io.open(os.getenv("JS_SBOM_FILE_LOCATION"), "w")
         if f == nil then
-            ngx.log(ngx.ERR, err)
+            ngx.log(ngx.ERR, "Failed to open JS SBOM file: ", err)
             return
         end
 
@@ -91,9 +91,13 @@ header_filter_by_lua_block {
     end
   end
 
+  local js_sbom_enabled = os.getenv("JS_SBOM_ENABLED")
+  if not js_sbom_enabled or js_sbom_enabled ~= 'true' then
+      return
+  end
+
   if not filter_queue then
-    ngx.log(ngx.ERR, 'Starting processQueue worker')
-    local hdl, err = ngx.timer.every(5, processQueue)
+    local hdl, err = ngx.timer.every(15, processQueue)
   end
 }
 


### PR DESCRIPTION
* Skip processQueue startup if not JS_SBOM_ENABLED.
* Run timer every 15s instead of 5s.
* Remove startup log to reduce noise.