### PR TITLE
[GOVCMS-11933] Use new govcmstests/tests version that supports behat

### DIFF
--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -31,7 +31,7 @@ COPY .docker/images/govcms/mariadb-client.cnf /etc/my.cnf.d
 COPY --from=cli /app /app
 
 # Copy PHPUnit configuration and test files
-COPY --from=govcmstesting/tests:3.2.0 /tests /app/tests
+COPY --from=govcmstesting/tests:3.2.1 /tests /app/tests
 
 # Set an environment variable for the webroot path
 ENV WEBROOT=web


### PR DESCRIPTION
`govcmstests/tests` version 3.2.1 reintroduces support for behat tests, so we update the version here.

Note that the latest version is actually 3.5.0, but I would consider it stale so we have decided to introduce a patch on the currently included version, which is 3.2.0.