### PR TITLE
Chore: Update to to Lagoon image version 25.3.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=3.23.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=25.2.0
+LAGOON_IMAGE_VERSION=25.3.0
 
 # Set the Shipshape version to use for the upstream dockerfiles (e.g. 1.0.0-alpha.1.5.0)
 # See https://github.com/salsadigitalauorg/shipshape/releases


### PR DESCRIPTION
- This bumps the Lagoon base image version to `25.3.0` to address CVE-2025-1219