### PR TITLE
Chore: Update to Lagoon image version 25.4.0 to disable SSL in mariadb-client 11.4.

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=3.23.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=25.3.0
+LAGOON_IMAGE_VERSION=25.4.0
 
 # Set the Shipshape version to use for the upstream dockerfiles (e.g. 1.0.0-alpha.1.5.0)
 # See https://github.com/salsadigitalauorg/shipshape/releases


### PR DESCRIPTION
## Issue:
* GovCMS image installs latest mariadb-client https://github.com/govCMS/GovCMS/blob/3.x-develop/.docker/Dockerfile.govcms#L11
```
cli-drupal:/app$ mariadb --version
mariadb from 11.4.5-MariaDB, client 15.2 for Linux (aarch64) using readline 5.1
```
* Since MariaDB 11.4, secure connection is enabled by default https://mariadb.com/kb/en/securing-connections-for-client-and-server/#enabling-tls-for-mariadb-server
* Some Drush SQL commands fail due to SSL error, eg. `sql:drop`, `sql:create`, or `drush si` used by `ahoy install`:
```
$ ahoy install
 You are about to:
 * CREATE the 'drupal' database.

 // Do you want to continue?: yes.

 [warning] Failed to drop or create the database. Do it yourself before installing. mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it

 [notice] Starting Drupal installation. This takes a while.
...
```
* Lagoon image 25.4.0 has an updated `drush.yml` with SSL disabled for the relevant commands: https://github.com/uselagoon/lagoon-images/blob/25.4.0/images/php-cli-drupal/drush.yml