### PR TITLE
[GOVCMSD10-1339] Mark Video Embed Field module as obsolete

### DIFF
--- a/modules/distro/video_embed_field/modules/video_embed_media/video_embed_media.info.yml
+++ b/modules/distro/video_embed_field/modules/video_embed_media/video_embed_media.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Integrates video_embed_field with the Media module, creating a new media type tailored to display embedded videos. Useful for websites which are using the media suite of modules.'
 package: Video Embed Field
 lifecycle: obsolete
+lifecycle_link: 'https://github.com/GovCMS/GovCMS'
 core_version_requirement: ^9.2 || ^10
 dependencies:
   - drupal:media (>= 8.4)

--- a/modules/distro/video_embed_field/modules/video_embed_media/video_embed_media.info.yml
+++ b/modules/distro/video_embed_field/modules/video_embed_media/video_embed_media.info.yml
@@ -1,7 +1,8 @@
-name: Video Embed Media
+name: Video Embed Media [OBSOLETE - DO NOT USE]
 type: module
 description: 'Integrates video_embed_field with the Media module, creating a new media type tailored to display embedded videos. Useful for websites which are using the media suite of modules.'
 package: Video Embed Field
+lifecycle: obsolete
 core_version_requirement: ^9.2 || ^10
 dependencies:
   - drupal:media (>= 8.4)

--- a/modules/distro/video_embed_field/modules/video_embed_wysiwyg/video_embed_wysiwyg.info.yml
+++ b/modules/distro/video_embed_field/modules/video_embed_wysiwyg/video_embed_wysiwyg.info.yml
@@ -1,7 +1,8 @@
-name: Video Embed WYSIWYG
+name: Video Embed WYSIWYG [OBSOLETE - DO NOT USE]
 type: module
 description: 'Integrates video_embed_field directly into ckeditor. Useful for websites not using the media suite of modules that need WYSIWYG support.'
 package: Video Embed Field
+lifecycle: obsolete
 core_version_requirement: ^9.2 || ^10
 dependencies:
   - drupal:field

--- a/modules/distro/video_embed_field/modules/video_embed_wysiwyg/video_embed_wysiwyg.info.yml
+++ b/modules/distro/video_embed_field/modules/video_embed_wysiwyg/video_embed_wysiwyg.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Integrates video_embed_field directly into ckeditor. Useful for websites not using the media suite of modules that need WYSIWYG support.'
 package: Video Embed Field
 lifecycle: obsolete
+lifecycle_link: 'https://github.com/GovCMS/GovCMS'
 core_version_requirement: ^9.2 || ^10
 dependencies:
   - drupal:field

--- a/modules/distro/video_embed_field/video_embed_field.info.yml
+++ b/modules/distro/video_embed_field/video_embed_field.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Provides a field type for displaying videos from 3rd party providers such as YouTube and Vimeo.'
 package: Video Embed Field
 lifecycle: obsolete
+lifecycle_link: 'https://github.com/GovCMS/GovCMS'
 core_version_requirement: ^9.2 || ^10
 dependencies:
   - drupal:field

--- a/modules/distro/video_embed_field/video_embed_field.info.yml
+++ b/modules/distro/video_embed_field/video_embed_field.info.yml
@@ -1,7 +1,8 @@
-name: Video Embed Field [DEPRECATED - DO NOT USE]
+name: Video Embed Field [OBSOLETE - DO NOT USE]
 type: module
 description: 'Provides a field type for displaying videos from 3rd party providers such as YouTube and Vimeo.'
 package: Video Embed Field
+lifecycle: obsolete
 core_version_requirement: ^9.2 || ^10
 dependencies:
   - drupal:field


### PR DESCRIPTION
Marked the Video Embed Field module and its submodules (video_embed_wysiwyg, video_embed_media) as obsolete.