### PR TITLE
[GOVCMSD11-181] Mark modules obsolete — purge_purger_http, page_manager, page_manager_ui

### DIFF
--- a/modules/distro/d8-stubs/page_manager/page_manager.info.yml
+++ b/modules/distro/d8-stubs/page_manager/page_manager.info.yml
@@ -1,3 +1,5 @@
 name: page_manager
 type: module
 core_version_requirement: ^9 || ^10
+lifecycle: obsolete
+lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/distro/d8-stubs/page_manager_ui/page_manager_ui.info.yml
+++ b/modules/distro/d8-stubs/page_manager_ui/page_manager_ui.info.yml
@@ -1,3 +1,5 @@
 name: page_manager_ui
 type: module
 core_version_requirement: ^9 || ^10
+lifecycle: obsolete
+lifecycle_link: 'https://github.com/GovCMS/GovCMS'

--- a/modules/scaffold-tooling/stubs/purge_purger_http/purge_purger_http.info.yml
+++ b/modules/scaffold-tooling/stubs/purge_purger_http/purge_purger_http.info.yml
@@ -1,3 +1,5 @@
 name: purge_purger_http
 type: module
 core_version_requirement: ^8 || ^9 || ^10
+lifecycle: obsolete
+lifecycle_link: 'https://github.com/GovCMS/GovCMS'


### PR DESCRIPTION
Mark purge_purger_http, page_manager, and page_manager_ui modules as obsolete.