### PR TITLE
[GOVCMSD11-331] Update lagoon base images from 25.7.0 to 25.9.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=4.x-develop-dev
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=25.7.0
+LAGOON_IMAGE_VERSION=25.9.0
 
 # Set the CLI image name
 # Support both legacy (govcms8lagoon/govcms8) and newer (govcms/govcms) images.


### PR DESCRIPTION
lagoon-images 25.9.0
[Release lagoon-images 25.9.0 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/25.9.0)

lagoon-images 25.8.0
[Release lagoon-images 25.8.0 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/25.8.0)