### PR TITLE
chore: update govcmstesting/tests image to 3.2.4

### DIFF
--- a/.docker/Dockerfile.test
+++ b/.docker/Dockerfile.test
@@ -31,7 +31,7 @@ COPY .docker/images/govcms/mariadb-client.cnf /etc/my.cnf.d
 COPY --from=cli /app /app
 
 # Copy PHPUnit configuration and test files
-COPY --from=govcmstesting/tests:3.2.3-php8.3 /tests /app/tests
+COPY --from=govcmstesting/tests:3.2.4-php8.3 /tests /app/tests
 
 # Set an environment variable for the webroot path
 ENV WEBROOT=web


### PR DESCRIPTION
https://github.com/govcms-tests/tests/releases/tag/3.2.4 reintroduced support for PHPUnit tests by adding it back as a dependency.

This PR updates the `govcmstesting/tests` image to use the latest supported tag.