### PR TITLE
[GOVCMS-13132] Changed Nginx configuration rules to allow SAML assets.

### DIFF
--- a/.docker/images/nginx/location_prepend_simplesamlphp.conf
+++ b/.docker/images/nginx/location_prepend_simplesamlphp.conf
@@ -19,3 +19,10 @@ location ~ /${LAGOON_PROJECT:-govcms}-saml/module.php/saml/sp/(saml2-logout\.php
         }
 }
 
+# Serve only static assets (JS/CSS/images) for SAML auto-post page.
+location ^~ /${LAGOON_PROJECT:-govcms}-saml/assets/ {
+    alias /app/vendor/simplesamlphp/simplesamlphp/public/assets/;
+    access_log off;
+    expires 1h;
+    add_header Cache-Control "public";
+}


### PR DESCRIPTION
# Issue

When using the SSO HTTP-POST binding, the `/saml_login` page gets stuck because the browser could not load required static assets (`post.js` and `postSubmit.css`) from the SimpleSAMLphp directory.

Requests to `/[project]-saml/assets/` returned 404 HTML responses, causing strict MIME type errors and preventing the SAML auto-submit from executing.

# Proposed solution

Expose the SimpleSAMLphp `public/assets/ directory` under the existing `/[project]-saml/` path to allow static files (JS, CSS, images) to load correctly.
