### PR TITLE
[GOVCMS-13417] Added env var to allow error URL override.

### DIFF
--- a/.docker/config/simplesaml/metadata/saml20-idp-remote.php
+++ b/.docker/config/simplesaml/metadata/saml20-idp-remote.php
@@ -47,6 +47,7 @@ foreach ($bindingKeys as $key) {
 $metadata[$idpEntityId] = [
   'entityid' => $idpEntityId,
   'contacts' => [],
+  'errorURL' => getenv('SIMPLESAMLPHP_SP_ERROR_URL') ?: null,
   'metadata-set' => 'saml20-idp-remote',
   'sign.authnrequest' => filter_var(getenv('SIMPLESAMLPHP_IDP_SIGN_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
   'SingleSignOnService' => [],


### PR DESCRIPTION
# Issue
Currently, when SimpleSAMLphp library encounters an error/rejection in the authentication flow the users get redirected to a generic “Unhandled exception” error page generated by SimpleSAMLphp library. The error might happen due to various reasons, e.g. when a user “Cancels” the authentication from the IdP. Because SimpleSAMLphp operates outside of Drupal, it does not know what to do in that situation, hence the generic error page.


# Proposed solution
To improve the UX, there is a [ErrorURL](https://simplesamlphp.org/docs/stable/simplesamlphp-sp-api.html) setting that can be set in the SP metadata to redirect users to a page that receives errors that may occur during authentication flow. This setting defaults to null as it is now, but optionally could be overwritten via an env variable to allow customers to customise this (e.g. return back to login page with a Drupal message).
