### PR TITLE
[GOVCMS-13521] Ensure solr index is created on first run (#526)

### DIFF
--- a/.docker/images/solr/900-prepare-index.sh
+++ b/.docker/images/solr/900-prepare-index.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -eu
+
 # Prepare the index.
 #
 # If the release requires a configset update then an
@@ -9,6 +11,7 @@
 
 INDEX="${INDEX:-drupal}"
 CONFIGSET="${CONFIGSET:-/opt/solr/server/solr/configsets/drupal}"
+GOVCMS_SOLR_RECREATE="${GOVCMS_SOLR_RECREATE:-}"
 
 # The following scripts are provided by the base images.
 if [ -n "$GOVCMS_SOLR_RECREATE" ]; then
@@ -18,5 +21,6 @@ if [ -n "$GOVCMS_SOLR_RECREATE" ]; then
 else
   # solr-precreate will initialise the solr data/conf directories
   # if they exist on disk, this will skip.
+  mkdir -p /var/solr/data
   solr-precreate "$INDEX" "$CONFIGSET"
 fi


### PR DESCRIPTION
After the solr9 upgrade, the entrypoint was failing with the error "cp: cannot create directory '/var/solr/data/drupal': No such file or directory". After adding the instruction to create the `/var/solr/data` directory, local tests no longer show the error.