### PR TITLE
[GOVCMSD11-498] Update lagoon base images from 25.9.0 to 25.12.1

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=4.0.0
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=25.9.0
+LAGOON_IMAGE_VERSION=25.12.1
 
 # Set the Shipshape version to use for the upstream dockerfiles (e.g. 1.0.0-alpha.1.5.0)
 # See https://github.com/salsadigitalauorg/shipshape/releases


### PR DESCRIPTION
lagoon-images 25.12.1
[Release 25.12.1 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/25.12.1) 

lagoon-images 25.12.0
[Release lagoon-images 25.12.0 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/25.12.0) 

lagoon-images 25.11.0
[Release lagoon-images 25.11.0 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/25.11.0) 

lagoon-images 25.10.0
[Release lagoon-images 25.10.0 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/25.10.0) 
