### PR TITLE
New composer script handler to deploy SimpleSAMLphp assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,12 @@
         ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
+            "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
+            "DrupalProject\\composer\\ScriptHandler::installSimpleSamlAssets"
         ],
         "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
+            "DrupalProject\\composer\\ScriptHandler::installSimpleSamlAssets"
         ]
     },
     "extra": {

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -89,4 +89,56 @@ class ScriptHandler {
     }
   }
 
+  /**
+   * Installs SimpleSAMLphp assets-base to public/assets/base/.
+   *
+   * The simplesamlphp/composer-module-installer plugin is
+   * intentionally disabled in this project to prevent automatic
+   * installation of all SimpleSAMLphp modules. This method
+   * manually copies only the simplesamlphp-assets-base package,
+   * which provides the JavaScript (post.js) required for
+   * HTTP-POST binding auto-submit.
+   *
+   * @param \Composer\Script\Event $event
+   *   The Composer event.
+   */
+  public static function installSimpleSamlAssets(Event $event) {
+    $fs = new Filesystem();
+    $vendorDir = $event->getComposer()->getConfig()
+      ->get('vendor-dir');
+    $source = $vendorDir
+      . '/simplesamlphp/simplesamlphp-assets-base';
+    $dest = $vendorDir
+      . '/simplesamlphp/simplesamlphp/public/assets/base';
+
+    if (!$fs->exists($source)) {
+      $event->getIO()->write(
+        '<warning>SimpleSAMLphp assets-base package '
+        . 'not found, skipping.</warning>'
+      );
+      return;
+    }
+
+    // Only copy web asset directories, ignoring files
+    // like .gitignore, .gitattributes, composer.json.
+    $assetDirs = ['css', 'js', 'icons', 'webfonts'];
+
+    foreach ($assetDirs as $dir) {
+      $dirSource = $source . '/' . $dir;
+      $dirDest = $dest . '/' . $dir;
+      if (!$fs->exists($dirSource)) {
+        continue;
+      }
+      if ($fs->exists($dirDest)) {
+        $fs->remove($dirDest);
+      }
+      $fs->mirror($dirSource, $dirDest);
+    }
+
+    $event->getIO()->write(
+      'SimpleSAMLphp assets-base installed '
+      . 'to public/assets/base/'
+    );
+  }
+
 }


### PR DESCRIPTION
Instead of enabling the `composer-module-installer` plugin, this PR adds a custom Composer script handler (`installSimpleSamlAssets`) that:

1. Keeps `"simplesamlphp/composer-module-installer": false` — no other SSP modules can auto-install
2. Copies **only** the web-asset directories (`css`, `js`, `icons`, `webfonts`) from `simplesamlphp-assets-base` module into the asset folder required by a HTTP-POST binding login form.
3. Ignores non-asset files (`.gitignore`, `.gitattributes`, `composer.json`)
4. Runs automatically on `composer install` and `composer update` via `post-install-cmd` / `post-update-cmd`
5. Uses the existing `ScriptHandler.php` pattern and `Symfony\Component\Filesystem` already available in the project