### PR TITLE
[GOVCMS-13360] Disable SAML SLO fallbacks.

### DIFF
--- a/.docker/config/simplesaml/metadata/saml20-idp-remote.php
+++ b/.docker/config/simplesaml/metadata/saml20-idp-remote.php
@@ -2,6 +2,7 @@
 
 $idpBaseURL = getenv('SIMPLESAMLPHP_IDP_BASE_URL');
 $idpEntityId = getenv('SIMPLESAMLPHP_IDP_ENTITYID') ?: $idpBaseURL;
+$singleLogOut = getenv('SIMPLESAMLPHP_SP_SLO') ?: false;
 $fallbackBinding = getenv('SIMPLESAMLPHP_IDP_DEFAULT_BINDING');
 
 $bindingKeys = [
@@ -23,7 +24,7 @@ foreach ($bindingKeys as $key) {
     $envVar = getenv($key);
 
     // Special for LOGOUT: fallback to non-logout sibling if present.
-    if (str_contains($key, 'LOGOUT') && empty($envVar)) {
+    if (str_contains($key, 'LOGOUT') && empty($envVar) && $singleLogOut) {
         $nonLogoutKey = str_replace('LOGOUT_', '', $key);
         $envVar = getenv($nonLogoutKey);
     }

--- a/.docker/images/nginx/location_prepend_simplesamlphp.conf
+++ b/.docker/images/nginx/location_prepend_simplesamlphp.conf
@@ -19,3 +19,10 @@ location ~ /${LAGOON_PROJECT:-govcms}-saml/module.php/saml/sp/(saml2-logout\.php
         }
 }
 
+# Serve only static assets (JS/CSS/images) for SAML auto-post page.
+location ^~ /${LAGOON_PROJECT:-govcms}-saml/assets/ {
+    alias /app/vendor/simplesamlphp/simplesamlphp/public/assets/;
+    access_log off;
+    expires 1h;
+    add_header Cache-Control "public";
+}

--- a/.docker/images/nginx/location_prepend_simplesamlphp.conf
+++ b/.docker/images/nginx/location_prepend_simplesamlphp.conf
@@ -18,3 +18,4 @@ location ~ /${LAGOON_PROJECT:-govcms}-saml/module.php/saml/sp/(saml2-logout\.php
             }
         }
 }
+

--- a/.docker/images/nginx/location_prepend_simplesamlphp.conf
+++ b/.docker/images/nginx/location_prepend_simplesamlphp.conf
@@ -18,11 +18,3 @@ location ~ /${LAGOON_PROJECT:-govcms}-saml/module.php/saml/sp/(saml2-logout\.php
             }
         }
 }
-
-# Serve only static assets (JS/CSS/images) for SAML auto-post page.
-location ^~ /${LAGOON_PROJECT:-govcms}-saml/assets/ {
-    alias /app/vendor/simplesamlphp/simplesamlphp/public/assets/;
-    access_log off;
-    expires 1h;
-    add_header Cache-Control "public";
-}


### PR DESCRIPTION
# Issue
Current remote metadata configuration dynamically sets logout bindings. When no specific value for a logout binding is set, it falls back onto its corresponding login binding location. While this works for some IdP, this can cause issues with other IdPs that produce an error on attempts to process SP-initiated SingleLogoutService request.

In addition, it is arguably better to not enable SP-initiated SLO by default, and only do so on case-by-case basis. 

# Proposed solution
Introduce a check for `SIMPLESAMLPHP_SP_SLO` env variable with a default of `false` when not present. When `false`, no fallback location will be used for `SingleLogoutService` binding, effectively deactivating SP-initiated SLO. Practically, this means that when the user logs out - the log out only happens from Drupal without involving IdP.