### PR TITLE
Add ForceAuthn option for SimpleSAMLphp SP configuration.

### DIFF
--- a/.docker/config/simplesaml/config/authsources.php
+++ b/.docker/config/simplesaml/config/authsources.php
@@ -46,7 +46,7 @@ $config = [
         'NameIDPolicy' => [],
 
         // Force authentication allows you to force re-authentication of users even if the user has a SSO session at the IdP.    
-        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
+        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false,
 
         // The URL to the discovery service.
         // Can be NULL/unset, in which case a builtin discovery service will be used.

--- a/.docker/config/simplesaml/config/authsources.php
+++ b/.docker/config/simplesaml/config/authsources.php
@@ -45,6 +45,9 @@ $config = [
         // the SP sets the AllowCreate attribute on the NameIDPolicy element to 'true”.
         'NameIDPolicy' => [],
 
+        // Force authentication allows you to force re-authentication of users even if the user has a SSO session at the IdP.    
+        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
+
         // The URL to the discovery service.
         // Can be NULL/unset, in which case a builtin discovery service will be used.
         'discoURL' => null,

--- a/.docker/config/simplesaml/metadata/saml20-idp-remote.php
+++ b/.docker/config/simplesaml/metadata/saml20-idp-remote.php
@@ -47,6 +47,7 @@ foreach ($bindingKeys as $key) {
 $metadata[$idpEntityId] = [
   'entityid' => $idpEntityId,
   'contacts' => [],
+  'errorURL' => getenv('SIMPLESAMLPHP_SP_ERROR_URL') ?: null,
   'metadata-set' => 'saml20-idp-remote',
   'sign.authnrequest' => filter_var(getenv('SIMPLESAMLPHP_IDP_SIGN_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
   'SingleSignOnService' => [],


### PR DESCRIPTION
# Issue
`ForceAuthn` is a SAML authentication request flag that instructs the Identity Provider (IdP) to re-authenticate the user rather than relying on an existing SSO session. When enabled, the Service Provider (SP) asks the IdP to perform a fresh authentication each time a login occurs, which helps ensure that the identity assertion is based on a current user verification rather than a previously established session. 

Enabling `ForceAuthn` improves security by reducing the risk of session reuse, stale authentication, or unintended access from shared or previously authenticated browsers, and aligns with best practices for sensitive systems where stronger assurance of the user’s presence and identity is desirable.

# Proposed solution
Introduce `SIMPLESAMLPHP_SP_FORCE_AUTH` env var that can control the value of `ForceAuthn` configuraiton option.