### PR TITLE
fix: inability to parametrise govcms version in cli image builds

### DIFF
--- a/.docker/Dockerfile.govcms
+++ b/.docker/Dockerfile.govcms
@@ -22,7 +22,7 @@ RUN case $(uname -m) in x86_64)  ARCH="amd64" ;; aarch64) ARCH="arm64" ;; *) ARC
 # Install jq for YAML/JSON parsing.
 RUN apk add jq
 
-RUN sed -i -e "/govcms\/govcms/ s!3.x-develop-dev!${GOVCMS_PROJECT_VERSION}!" /app/composer.json
+RUN sed -i -e "/govcms\/govcms/ s!dev-4.x-develop!${GOVCMS_PROJECT_VERSION}!" /app/composer.json
 
 COPY scripts/composer/ScriptHandler.php /app/scripts/composer/ScriptHandler.php
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
-        "govcms/govcms": "4.2.0",
+        "govcms/govcms": "dev-4.x-develop",
         "govcms/govcms-custom": "*",
         "govcms/scaffold-tooling": "6.0.5"
     },


### PR DESCRIPTION
# Description

Internal ticket: [GOVCMS-14461](https://osbfinance.atlassian.net/browse/GOVCMS-14461)

There is an issue with the `cli` dockerfile that results in `ahoy build` not building images correctly. In particular, there is a regression in the ability to parametrise by the GovCMS version. It has not been updated to work with the `4.x-develop` branch.

Also, the `govcms/govcms` package version in the `composer.json` file should be changed to point to the respective develop branch, as was the case in the `3.x-develop` branch: https://github.com/govCMS/lagoon/blob/8abe61c0af4e14f26d03ee4e0673aad38fedbd0e/composer.json#L20 (noting the `dev` should actually come first).

