### PR TITLE
feat: saasplus image

### DIFF
--- a/.docker/Dockerfile.govcms-saasplus
+++ b/.docker/Dockerfile.govcms-saasplus
@@ -1,0 +1,12 @@
+ARG GOVCMS_IMAGE
+
+FROM ${GOVCMS_IMAGE}
+
+ENV COMPOSER_MEMORY_LIMIT=-1
+
+# Add the custom packages repository and install SaaS+ modules.
+COPY custom /app/custom
+RUN --mount=type=secret,id=composer-auth,dst=/app/auth.json \
+    /usr/local/bin/composer config repositories.custom path custom/composer -d /app \
+    && /usr/local/bin/composer require --no-interaction --update-no-dev -d /app govcms/govcms-custom \
+    && /usr/local/bin/composer clearcache

--- a/bake.hcl
+++ b/bake.hcl
@@ -1,9 +1,14 @@
 group "default" {
-    targets = ["cli", "test", "nginx", "php", "mariadb", "redis", "solr", "varnish"]
+    targets = ["cli", "cli-saasplus", "test", "nginx", "php", "mariadb", "redis", "solr", "varnish"]
 }
 
 target "cli" {
     dockerfile = ".docker/Dockerfile.govcms"
+    platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "cli-saasplus" {
+    dockerfile = ".docker/Dockerfile.govcms-saasplus"
     platforms = ["linux/amd64", "linux/arm64"]
 }
 

--- a/composer.json
+++ b/composer.json
@@ -7,17 +7,12 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "path",
-            "url": "custom/composer"
         }
     ],
     "require": {
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "govcms/govcms": "dev-4.x-develop",
-        "govcms/govcms-custom": "*",
         "govcms/scaffold-tooling": "6.0.5"
     },
     "require-dev": {

--- a/custom/composer/composer.json
+++ b/custom/composer/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "govcms/govcms-custom",
-    "description": "Provides additional packages over the GovCMS base distribution.",
+    "description": "Provides additional packages over the GovCMS base distribution for SaaS+ sites.",
     "require": {
+        "drupal/webform_openfisca": "^1.1"
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,16 @@ services:
       LAGOON_ROUTE: ${LOCALDEV_URL:-http://govcmslagoon.docker.amazee.io}
     << : *default-volumes
 
+  cli-saasplus:
+    build:
+      context: .
+      dockerfile: $PWD/.docker/Dockerfile.govcms-saasplus
+      args:
+        GOVCMS_IMAGE: ${DOCKERHUB_NAMESPACE:-govcms}/${GOVCMS_CLI_IMAGE_NAME:-govcms}:${GOVCMS_RELEASE_TAG:-latest}
+        COMPOSER_AUTH: ${COMPOSER_AUTH:-}
+    image: ${DOCKERHUB_NAMESPACE:-govcms}/govcms-saasplus:${GOVCMS_RELEASE_TAG:-latest}
+    depends_on:
+      - cli
 
   test:
     build:


### PR DESCRIPTION
# Description

Introduces a new `govcms-saasplus` image that is exactly the same as the normal GovCMS image, but with the SaaS+ modules included via the `/custom/composer/composer.json` file. Note that the GovCMS image now does not consume this file, so it does NOT get these modules.

SaaS+ sites can then consume this image instead of the default one on a case by case basis.

Having the modules listed and controlled at the lagoon image layer means that we automatically control module versions and keep them updated using dependabot, etc.

I've only included `drupal/webform_opensfisca` for now as an example, but before merging this PR we would include them all.