### PR TITLE
[GOVCMS-14757] SimpleSAMLphp configuration hardening

### DIFF
--- a/.docker/config/simplesaml/config/authsources.php
+++ b/.docker/config/simplesaml/config/authsources.php
@@ -46,7 +46,7 @@ $config = [
         'NameIDPolicy' => [],
 
         // Force authentication allows you to force re-authentication of users even if the user has a SSO session at the IdP.    
-        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
+        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false,
 
         // The URL to the discovery service.
         // Can be NULL/unset, in which case a builtin discovery service will be used.

--- a/.docker/config/simplesaml/config/authsources.php
+++ b/.docker/config/simplesaml/config/authsources.php
@@ -46,7 +46,7 @@ $config = [
         'NameIDPolicy' => [],
 
         // Force authentication allows you to force re-authentication of users even if the user has a SSO session at the IdP.    
-        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false,
+        'ForceAuthn' => filter_var(getenv('SIMPLESAMLPHP_SP_FORCE_AUTH'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
 
         // The URL to the discovery service.
         // Can be NULL/unset, in which case a builtin discovery service will be used.
@@ -100,7 +100,7 @@ $config = [
          * The value is also used to set the WantAssertionsSigned attribute
          * of the SPSSODescriptor element in the exported SAML 2.0 metadata.
          */
-        'WantAssertionsSigned' => filter_var(getenv('SIMPLESAMLPHP_SP_WANT_ASSERTIONS_SIGNED'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false,
+        'WantAssertionsSigned' => filter_var(getenv('SIMPLESAMLPHP_SP_WANT_ASSERTIONS_SIGNED'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
 
         /*
          * Whether we require signatures on authentication requests sent from this SP. Set it to:

--- a/.docker/config/simplesaml/config/config.php
+++ b/.docker/config/simplesaml/config/config.php
@@ -6,6 +6,22 @@
 
 $httpUtils = new \SimpleSAML\Utils\HTTP();
 
+$simplesaml_debug = filter_var(getenv('GOVCMS_SIMPLESAML_DEBUG'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+$simplesaml_log_level = strtoupper((string) (getenv('GOVCMS_SIMPLESAML_LOG_LEVEL') ?: 'WARNING'));
+$simplesaml_logging_levels = [
+    'EMERG' => \SimpleSAML\Logger::EMERG,
+    'ALERT' => \SimpleSAML\Logger::ALERT,
+    'CRIT' => \SimpleSAML\Logger::CRIT,
+    'ERR' => \SimpleSAML\Logger::ERR,
+    'ERROR' => \SimpleSAML\Logger::ERR,
+    'WARNING' => \SimpleSAML\Logger::WARNING,
+    'NOTICE' => \SimpleSAML\Logger::NOTICE,
+    'INFO' => \SimpleSAML\Logger::INFO,
+    'DEBUG' => \SimpleSAML\Logger::DEBUG,
+];
+// Default to WARNING level if the log level is not set or invalid.
+$simplesaml_logging_level = $simplesaml_logging_levels[$simplesaml_log_level] ?? \SimpleSAML\Logger::WARNING;
+
 $config = [
 
     /*******************************
@@ -187,8 +203,11 @@ $config = [
      *
      * A possible way to generate a random salt is by running the following command from a unix shell:
      * LC_ALL=C tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo
+     *
+     * When GOVCMS_SIMPLESAML_SALT is unset, the salt is derived from LAGOON_PROJECT (deterministic; fine for
+     * local development only). Production must set GOVCMS_SIMPLESAML_SALT to a secret value.
      */
-    'secretsalt' => getenv('GOVCMS_SIMPLESAML_SALT') ?: 'Yy)IUE:O*mNNACtJZIWKagjnUgqk@apz#7nB*b*20YH1eIOQ9z_gfCcR6OVZ1KgF',
+    'secretsalt' => getenv('GOVCMS_SIMPLESAML_SALT') ?: '',
 
     /*
      * This password must be kept secret, and modified from the default value 123.
@@ -201,7 +220,7 @@ $config = [
     /*
      * Set this option to true if you want to require administrator password to access the metadata.
      */
-    'admin.protectmetadata' => false,
+    'admin.protectmetadata' => filter_var(getenv('GOVCMS_SIMPLESAML_PROTECT_METADATA'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
 
     /*
      * Set this option to false if you don't want SimpleSAMLphp to check for new stable releases when
@@ -320,9 +339,9 @@ $config = [
      * empty array.
      */
     'debug' => [
-        'saml' => true,
-        'backtraces' => true,
-        'validatexml' => true,
+        'saml' => $simplesaml_debug,
+        'backtraces' => $simplesaml_debug,
+        'validatexml' => $simplesaml_debug,
     ],
 
     /*
@@ -356,6 +375,8 @@ $config = [
      * - SimpleSAML\Logger::INFO    Verbose logs
      * - SimpleSAML\Logger::DEBUG   Full debug logs - not recommended for production
      *
+     * Level is read from GOVCMS_SIMPLESAML_LOG_LEVEL (default WARNING); unknown values use WARNING.
+     *
      * Choose logging handler.
      *
      * Options: [syslog,file,errorlog,stderr]
@@ -364,7 +385,7 @@ $config = [
      * must exist and be writable for SimpleSAMLphp. If set to something else, set
      * loggingdir above to 'null'.
      */
-    'logging.level' => SimpleSAML\Logger::DEBUG,
+    'logging.level' => $simplesaml_logging_level,
     'logging.handler' => 'errorlog',
 
     /*
@@ -478,7 +499,7 @@ $config = [
      * Ensure that you have the required PDO database driver installed
      * for your connection string.
      */
-    'database.dsn' => 'mysql:host=' . getenv('MARIADB_HOST') ?: 'mariadb' . ';dbname=' . getenv('MARIADB_DATABASE') ?: 'drupal',
+    'database.dsn' => 'mysql:host=' . (getenv('MARIADB_HOST') ?: 'mariadb') . ';dbname=' . (getenv('MARIADB_DATABASE') ?: 'drupal'),
 
     /*
      * SQL database credentials
@@ -588,7 +609,7 @@ $config = [
     /*
      * Option to override the default settings for the session cookie name
      */
-    'session.cookie.name' => (getenv('GOVCMS_SIMPLESAML_SESSION_ID') ?: 'dofdirectory-d10') . '_saml_session_id',
+    'session.cookie.name' => (getenv('GOVCMS_SIMPLESAML_SESSION_ID') ?: getenv('LAGOON_PROJECT') ?: 'ssp') . '_saml_session_id',
 
     /*
      * Expiration time for the session cookie, in seconds.
@@ -658,7 +679,7 @@ $config = [
     /*
      * Option to override the default settings for the auth token cookie
      */
-    'session.authtoken.cookiename' => (getenv('GOVCMS_SIMPLESAML_AUTH_TOKEN') ?: 'dofdirectory-d10') . '_saml_auth_token',
+    'session.authtoken.cookiename' => (getenv('GOVCMS_SIMPLESAML_AUTH_TOKEN') ?: getenv('LAGOON_PROJECT') ?: 'ssp') . '_saml_auth_token',
 
     /*
      * Options for remember me feature for IdP sessions. Remember me feature

--- a/.docker/config/simplesaml/metadata/saml20-idp-remote.php
+++ b/.docker/config/simplesaml/metadata/saml20-idp-remote.php
@@ -2,7 +2,7 @@
 
 $idpBaseURL = getenv('SIMPLESAMLPHP_IDP_BASE_URL');
 $idpEntityId = getenv('SIMPLESAMLPHP_IDP_ENTITYID') ?: $idpBaseURL;
-$singleLogOut = getenv('SIMPLESAMLPHP_SP_SLO') ?: false;
+$singleLogOut = getenv('SIMPLESAMLPHP_SP_SLO') ?: true;
 $fallbackBinding = getenv('SIMPLESAMLPHP_IDP_DEFAULT_BINDING');
 
 $bindingKeys = [


### PR DESCRIPTION
# Issue
Upon review it was identified that the current SimpleSAMLphp configuration should utilise some hardening.

# Proposed solution
- Disable debug by default.
- Set logging level to `WARNING` level by default.
- Remove hard-coded secret salt.
- Remove hard-coded admin pass.
- Enable metadata protection by default.
- Isolate cookie name by application.
- Enable SLO by default.