### PR TITLE
[GOVCMS-13537] docker-compose: Remove unused arguments GITHUB_TOKEN, COMPOSER_AUTH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
         SHIPSHAPE_VERSION: ${SHIPSHAPE_VERSION:-1.0.0-alpha.1.5.0}
         GOVCMS_PROJECT_VERSION: ${GOVCMS_PROJECT_VERSION:-2.x-dev}
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        COMPOSER_AUTH: ${COMPOSER_AUTH:-}
-        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     image: ${DOCKERHUB_NAMESPACE:-govcms}/${GOVCMS_CLI_IMAGE_NAME:-govcms}:${GOVCMS_RELEASE_TAG:-latest}
     environment:
       LAGOON_ROUTE: ${LOCALDEV_URL:-http://govcmslagoon.docker.amazee.io}
@@ -27,7 +25,6 @@ services:
       args:
         CLI_IMAGE: ${DOCKERHUB_NAMESPACE:-govcms}/${GOVCMS_CLI_IMAGE_NAME:-govcms}:${GOVCMS_RELEASE_TAG:-latest}
         LAGOON_IMAGE_VERSION: ${LAGOON_IMAGE_VERSION:-latest}
-        COMPOSER_AUTH: ${COMPOSER_AUTH:-}
     image: ${DOCKERHUB_NAMESPACE:-govcms}/test:${GOVCMS_RELEASE_TAG:-latest}
     depends_on:
       - cli


### PR DESCRIPTION
Internal Ticket: https://osbfinance.atlassian.net/browse/GOVCMS-13537

While evaluating the build pipeline for any potential leaks of sensitive tokens, some unused argument assignments were found in the docker-compose.yml file. These do not present a risk to the build pipeline as there are no corresponding `ARG` definitions in `Dockerfile.govcms` or `Dockerfile.test`, but still worth cleaning them up.

These would appear to be relics of the old method before build secrets were used to authenticate for composer (https://github.com/govCMS/lagoon/pull/388).