### PR TITLE
[GOVCMS-14555] Added HTTPAV identifier.

### DIFF
--- a/.docker/Dockerfile.php
+++ b/.docker/Dockerfile.php
@@ -5,6 +5,7 @@ FROM ${CLI_IMAGE} as cli
 FROM uselagoon/php-8.3-fpm:${LAGOON_IMAGE_VERSION}
 
 COPY .docker/images/php/01-govcms.ini /usr/local/etc/php/conf.d/
+COPY .docker/images/php/99-httpav-id.conf /usr/local/etc/php-fpm.d/99-httpav-id.conf
 COPY --from=cli /app /app
 COPY .docker/sanitize.sh /app/sanitize.sh
 

--- a/.docker/images/php/99-httpav-id.conf
+++ b/.docker/images/php/99-httpav-id.conf
@@ -1,0 +1,5 @@
+; HTTPAV identifier passed into PHP for FPM requests (not visible to CLI/php -r).
+; Expanded at container start by envplate (see Lagoon 70-php-config.sh) from Lagoon’s
+; project and environment names. Pool name must match the active pool (usually www).
+[www]
+env[HTTPAV_IDENTIFIER] = ${LAGOON_PROJECT}-${LAGOON_ENVIRONMENT}


### PR DESCRIPTION
# Issue
HTTPAV Drupal module [has support](https://git.drupalcode.org/project/httpav/-/merge_requests/10/diffs#07c0fd262d6416a2866af7c75c783307659df88f_215_275) of `X-Requester-ID` header. If set, this header is then used by the AV service to supplement logs to better identify which environment instance the logs belong to.  Currently, it is impossible to correlate the logs to instances.

The value of the header is controlled via `HTTPAV_IDENTIFIER` environment variable, which is currently not set for any of instances on GovCMS.

# Proposed solution
Enhance PHP dockerfile to introduce a new PHP-FPM config that evaluates `HTTPAV_IDENTIFIER` at the container start as a concatenation of existing `LAGOON_PROJECT` and `LAGOON_ENVIRONMENT` vars (e.g. `projectName-develop`), which will provide a meaningful information to the logs to identify the instance when invoking the AV service.
