### PR TITLE
[GOVCMS-15030] Skip robots.txt overwrite from Drupal core.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,15 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[project-root]/recipes/README.txt": false,
+                "[web-root]/INSTALL.txt": false,
+                "[web-root]/modules/README.txt": false,
+                "[web-root]/profiles/README.txt": false,
+                "[web-root]/robots.txt": false,
+                "[web-root]/sites/README.txt": false,
+                "[web-root]/themes/README.txt": false
             }
         },
         "installer-paths": {


### PR DESCRIPTION
# Issue
GovCMS ships [RobotsTxt module](https://github.com/govCMS/GovCMS/blob/4.x-develop/composer.json#L101) and when enabled `robots.txt` is generated dynamically per site (and configurable in the admin UI). Drupal core’s Composer scaffold, by default, still installs a static web/robots.txt on every composer install / composer update.

When that file exists on disk, the web server typically serves it before Drupal boots. Crawlers and tools then see core’s default rules, not GovCMS/RobotsTxt configuration.

# Proposed solution
Disable scaffold for the path `"[web-root]/robots.txt": false` to stop Composer from creating or overwriting `robots.txt`, so RobotsTxt remains the single source of truth.