### PR TITLE
[GOVCMSD11-648] Update lagoon base images from 26.5.1 to 26.6.0

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -39,7 +39,7 @@ GOVCMS_PROJECT_VERSION=4.3.2
 
 # Set the Lagoon tag to use for the upstream dockerfiles (e.g. 20.12.0)
 # See https://github.com/uselagoon/lagoon-images/releases
-LAGOON_IMAGE_VERSION=26.5.1
+LAGOON_IMAGE_VERSION=26.6.0
 
 # Set the Shipshape version to use for the upstream dockerfiles (e.g. 1.0.0-alpha.1.5.0)
 # See https://github.com/salsadigitalauorg/shipshape/releases


### PR DESCRIPTION
**lagoon-images 26.6.0**
[Release lagoon-images 26.6.0 · uselagoon/lagoon-images](https://github.com/uselagoon/lagoon-images/releases/tag/26.6.0) 