### PR TITLE
[GOVCMS-15332] Fixed evaluation of SIMPLESAMLPHP_SP_SLO variable.

### DIFF
--- a/.docker/config/simplesaml/metadata/saml20-idp-remote.php
+++ b/.docker/config/simplesaml/metadata/saml20-idp-remote.php
@@ -2,7 +2,7 @@
 
 $idpBaseURL = getenv('SIMPLESAMLPHP_IDP_BASE_URL');
 $idpEntityId = getenv('SIMPLESAMLPHP_IDP_ENTITYID') ?: $idpBaseURL;
-$singleLogOut = getenv('SIMPLESAMLPHP_SP_SLO') ?: true;
+$singleLogOut = filter_var(getenv('SIMPLESAMLPHP_SP_SLO'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
 $fallbackBinding = getenv('SIMPLESAMLPHP_IDP_DEFAULT_BINDING');
 
 $bindingKeys = [


### PR DESCRIPTION
# Issue

Currently `SIMPLESAMLPHP_SP_SLO` evaluation is not wrapped in `filter_var` causing it to evaluate to a truthy value regardless to what it is set. This creates a problem for customers that need Single Log Out disabled.

# Proposed solution
Wrap the evaluation with `filter_var` with `FILTER_VALIDATE_BOOLEAN` to enable correct evaluation of false.